### PR TITLE
Fix rendering twice issue

### DIFF
--- a/src/components/Region.js
+++ b/src/components/Region.js
@@ -19,7 +19,7 @@ export default React.createClass({
     name: PropTypes.string.isRequired
   },
 
-  componentDidMount() {
+  componentWillMount() {
     const observable = getObservable();
 
     this.subscription = observable.subscribe({


### PR DESCRIPTION
Issue:
Region component was rendered twice because of `setState` being called during `componentDidMount`

Fix
Change `componentDidMount` to `componentWillMount`.