### PR TITLE
Adds the createFactory spec

### DIFF
--- a/test/createComponent.spec.js
+++ b/test/createComponent.spec.js
@@ -5,11 +5,20 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import createComponent from '../src/createComponent';
 
+const sandbox = sinon.sandbox.create();
+
 chai.use(sinonChai);
-sinon.spy(React, 'createClass');
 
 
 describe('createComponent', function () {
+  beforeEach(function () {
+    sandbox.spy(React, 'createClass');
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
   it('creates a component', function () {
     const mySpec = {
       myCustomFunction() { return 'foo'; },

--- a/test/createFactory.spec.js
+++ b/test/createFactory.spec.js
@@ -10,7 +10,7 @@ describe('createFactory', function () {
     const fakeAppInstance = {};
     const mySpec = {
       initialize: sinon.stub(),
-      myCustomFunction: () => 'lol'
+      myCustomFunction: () => 'value'
     };
 
     const MyFactory = createFactory(mySpec);
@@ -25,6 +25,6 @@ describe('createFactory', function () {
 
     /* And contain the functions passed in the spec */
     expect('myCustomFunction' in myFactoryInstance).to.be.equal(true);
-    expect(myFactoryInstance.myCustomFunction()).to.be.equal('lol');
+    expect(myFactoryInstance.myCustomFunction()).to.be.equal('value');
   });
 });

--- a/test/createFactory.spec.js
+++ b/test/createFactory.spec.js
@@ -6,24 +6,25 @@ import createFactory from '../src/createFactory';
 chai.use(sinonChai);
 
 describe('createFactory', function () {
-  it('returns a Factory class', function () {
-    const fakeAppInstance = {};
-    const mySpec = {
-      initialize: sinon.stub(),
-      myCustomFunction: () => 'value'
-    };
+  const fakeAppInstance = {};
+  const mySpec = {
+    initialize: sinon.stub(),
+    myCustomFunction: () => 'value'
+  };
 
-    const MyFactory = createFactory(mySpec);
-    const myFactoryInstance = new MyFactory({ app: fakeAppInstance });
+  const MyFactory = createFactory(mySpec);
+  const myFactoryInstance = new MyFactory({ app: fakeAppInstance });
 
-    /** Executes the initialize() at construction */
+  it('executes the initialize() at construction', function () {
     expect(mySpec.initialize).to.be.callCount(1);
+  });
 
-    /** Must be an instance of MyFactory and contain the app instance passed */
+  it('must be an instance of MyFactory and have the app passed', function () {
     expect(myFactoryInstance).to.be.instanceOf(MyFactory);
     expect(myFactoryInstance.app).to.be.deep.equal(fakeAppInstance);
+  });
 
-    /* And contain the functions passed in the spec */
+  it('must contain the functions passed in the spec', function () {
     expect('myCustomFunction' in myFactoryInstance).to.be.equal(true);
     expect(myFactoryInstance.myCustomFunction()).to.be.equal('value');
   });

--- a/test/createFactory.spec.js
+++ b/test/createFactory.spec.js
@@ -1,0 +1,30 @@
+/* global describe, it */
+import chai, { expect } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import createFactory from '../src/createFactory';
+chai.use(sinonChai);
+
+describe('createFactory', function () {
+  it('returns a Factory class', function () {
+    const fakeAppInstance = {};
+    const mySpec = {
+      initialize: sinon.stub(),
+      myCustomFunction: () => 'lol'
+    };
+
+    const MyFactory = createFactory(mySpec);
+    const myFactoryInstance = new MyFactory({ app: fakeAppInstance });
+
+    /** Executes the initialize() at construction */
+    expect(mySpec.initialize).to.be.callCount(1);
+
+    /** Must be an instance of MyFactory and contain the app instance passed */
+    expect(myFactoryInstance).to.be.instanceOf(MyFactory);
+    expect(myFactoryInstance.app).to.be.deep.equal(fakeAppInstance);
+
+    /* And contain the functions passed in the spec */
+    expect('myCustomFunction' in myFactoryInstance).to.be.equal(true);
+    expect(myFactoryInstance.myCustomFunction()).to.be.equal('lol');
+  });
+});


### PR DESCRIPTION
# What does this PR do:
  - Adds the usage of `sinon.sandbox` to create and restore stubs/spies, to not pollute other tests.
  - Adds a new test for the `createFactory()`, only testing the result expectations.

![screen shot 2016-07-12 at 10 47 02](https://cloud.githubusercontent.com/assets/1002056/16760841/fdfce036-481d-11e6-9f37-603153585af1.png)

# Where should the reviewer start:
  - Diffs
  - Run `npm test`

# Unit and/or functional tests:
  - Adds the test `test/createFactory.spec.js`.