### PR TITLE
Optimise region to only re-render when listForRendering changes

### DIFF
--- a/src/components/Region.js
+++ b/src/components/Region.js
@@ -19,6 +19,27 @@ export default React.createClass({
     name: PropTypes.string.isRequired
   },
 
+  /**
+   * Determines if the the component should be updated or not.
+   * Since we are calling setState multiple times, we need to make sure that only when
+   * the list of widgets to render, i.e. this.state.listForRendering, is changed should
+   * trigger a re-render of the region component.
+   * @param  {Object}  nextProps  the next set of props
+   * @param  {Object}  nextState  the next component state to be set
+   * @return {Boolean} a boolean flag indicating whether the component should be updated
+   */
+  shouldComponentUpdate(nextProps, nextState) {
+    let shouldUpdate = !_.isEqual(this.props, nextProps);
+    if (!shouldUpdate) {
+      const { listForRendering } = nextState;
+      shouldUpdate = shouldUpdate || this.state.listForRendering.length !== listForRendering.length;
+      shouldUpdate = shouldUpdate ||
+        _.zipWith(this.state.listForRendering, listForRendering, (prev, next) => prev.name === next.name)
+          .some(value => !value);
+    }
+    return shouldUpdate;
+  },
+
   componentWillMount() {
     const observable = getObservable();
 
@@ -27,59 +48,59 @@ export default React.createClass({
       next: () => {
         this.setState({
           list: getWidgets(this.props.name)
-        });
+        }, () => {
 
-        this.state.list.forEach((widget) => {
-          if (!isRootAppAvailable()) {
-            return;
-          }
-
-          const widgetName = widget.getOption('name');
-
-          // @TODO: later re-implement this check with observables
-          const rootApp = widget.getRootApp();
-          const areDependenciesLoaded = widget.readableApps.length > 0
-            ? widget.readableApps.every((readableApp) => rootApp.getStore(readableApp))
-            : true;
-
-          if (!areDependenciesLoaded) {
-            return;
-          }
-
-          const existsInState = this.state.listForRendering.some((item) => {
-            return item.name === widgetName;
-          });
-
-          if (existsInState) {
-            return;
-          }
-
-          const WidgetComponent = widget.render();
-          const WrapperComponent = React.createClass({
-            componentWillMount() {
-              widget.beforeMount();
-            },
-
-            componentDidMount() {
-              widget.afterMount();
-            },
-
-            componentWillUnmount() {
-              widget.beforeUnmount();
-            },
-
-            render() {
-              return <WidgetComponent />;
+          this.state.list.forEach((widget) => {
+            if (!isRootAppAvailable()) {
+              return;
             }
-          });
 
-          const { listForRendering } = this.state;
-          listForRendering.push({
-            name: widgetName,
-            Component: WrapperComponent
-          });
+            const widgetName = widget.getOption('name');
 
-          this.setState({ listForRendering });
+            // @TODO: later re-implement this check with observables
+            const rootApp = widget.getRootApp();
+            const areDependenciesLoaded = widget.readableApps.length > 0
+              ? widget.readableApps.every((readableApp) => rootApp.getStore(readableApp))
+              : true;
+
+            if (!areDependenciesLoaded) {
+              return;
+            }
+
+            const existsInState = this.state.listForRendering.some((item) => {
+              return item.name === widgetName;
+            });
+
+            if (existsInState) {
+              return;
+            }
+
+            const WidgetComponent = widget.render();
+            const WrapperComponent = React.createClass({
+              componentWillMount() {
+                widget.beforeMount();
+              },
+
+              componentDidMount() {
+                widget.afterMount();
+              },
+
+              componentWillUnmount() {
+                widget.beforeUnmount();
+              },
+
+              render() {
+                return <WidgetComponent />;
+              }
+            });
+
+            const listForRendering = [...this.state.listForRendering, {
+              name: widgetName,
+              Component: WrapperComponent,
+            }];
+
+            this.setState({ listForRendering });
+          });
         });
       },
       error: (err) => {


### PR DESCRIPTION
Changes made:

1. Added callback after `setState` to make sure we have the list of registered widgets ready before iterating over list
1. Refactored direct state change prior to call to `this.setState({ listForRendering })`.  Now creates new `listForRendering` and call `setState`.
1. Implemented `shouldComponentUpdate` to make sure that after all dependencies are loaded, which causes a change to `this.state.listForRendering`, only then the component is re-rendered