### PR TITLE
Adds createService spec

### DIFF
--- a/test/createApp.spec.js
+++ b/test/createApp.spec.js
@@ -3,8 +3,8 @@ import { expect } from 'chai';
 
 import createApp from '../src/createApp';
 
-describe('createApp', function () {
-  it('creates an instance', function () {
+describe('createApp', () => {
+  it('creates an instance', () => {
     const App = createApp({
       name: 'MyAppName',
       appId: '123',

--- a/test/createComponent.spec.js
+++ b/test/createComponent.spec.js
@@ -8,7 +8,7 @@ import createComponent from '../src/createComponent';
 const sandbox = sinon.sandbox.create();
 chai.use(sinonChai);
 
-describe('createComponent', function () {
+describe('createComponent', () => {
   const mySpec = {
     myCustomFunction() { return 'foo'; },
     render() { return null; }
@@ -16,17 +16,17 @@ describe('createComponent', function () {
   let MyComponent;
   let myComponentInstance;
 
-  beforeEach(function () {
+  beforeEach(() => {
     sandbox.spy(React, 'createClass');
     MyComponent = createComponent(mySpec);
     myComponentInstance = new MyComponent();
   });
 
-  afterEach(function () {
+  afterEach(() => {
     sandbox.restore();
   });
 
-  it('calls React.createClass once, at component creation', function () {
+  it('calls React.createClass once, at component creation', () => {
     expect(React.createClass)
       .to.be.callCount(1)
       .and.to.be.calledWith({
@@ -37,12 +37,12 @@ describe('createComponent', function () {
       });
   });
 
-  it('is a valid React component and a MyComponent\'s instance', function () {
+  it('is a valid React component and a MyComponent\'s instance', () => {
     expect('isReactComponent' in Object.getPrototypeOf(myComponentInstance)).to.be.equal(true);
     expect(myComponentInstance).to.be.instanceof(MyComponent);
   });
 
-  it('has the spec\'s functions', function () {
+  it('has the spec\'s functions', () => {
     expect(myComponentInstance.myCustomFunction()).to.be.equal('foo');
     expect(myComponentInstance.render()).to.be.equal(null);
   });

--- a/test/createFactory.spec.js
+++ b/test/createFactory.spec.js
@@ -5,7 +5,7 @@ import sinonChai from 'sinon-chai';
 import createFactory from '../src/createFactory';
 chai.use(sinonChai);
 
-describe('createFactory', function () {
+describe('createFactory', () => {
   const fakeAppInstance = {};
   const mySpec = {
     initialize: sinon.stub(),
@@ -15,16 +15,20 @@ describe('createFactory', function () {
   const MyFactory = createFactory(mySpec);
   const myFactoryInstance = new MyFactory({ app: fakeAppInstance });
 
-  it('executes the initialize() at construction', function () {
+  it('throws error when an app instance is not provided', () => {
+    expect(() => new MyFactory()).to.throw(Error, 'App instance not provided.');
+  });
+
+  it('executes the initialize() at construction', () => {
     expect(mySpec.initialize).to.be.callCount(1);
   });
 
-  it('must be an instance of MyFactory and have the app passed', function () {
+  it('must be an instance of MyFactory and have the app passed', () => {
     expect(myFactoryInstance).to.be.instanceOf(MyFactory);
     expect(myFactoryInstance.app).to.be.deep.equal(fakeAppInstance);
   });
 
-  it('must contain the functions passed in the spec', function () {
+  it('must contain the functions passed in the spec', () => {
     expect('myCustomFunction' in myFactoryInstance).to.be.equal(true);
     expect(myFactoryInstance.myCustomFunction()).to.be.equal('value');
   });

--- a/test/createService.spec.js
+++ b/test/createService.spec.js
@@ -1,0 +1,48 @@
+/* global describe, it */
+import chai, { expect } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import createService from '../src/createService';
+chai.use(sinonChai);
+
+describe('createService', () => {
+  const mySpec = {
+    initialize: sinon.stub(),
+    customFunction1() { return 'value1'; },
+    customFunction2() { return 'value2'; },
+    returnsThis() { return this; }
+  };
+
+  const myOptions = {
+    app: {}
+  };
+
+  const MyService = createService(mySpec);
+  const myServiceInstance = new MyService(myOptions);
+
+  it('throws error when an app instance is not provided', () => {
+    expect(() => new MyService()).to.throw(Error, 'App instance not provided.');
+  });
+
+  it('creates instance from my service', () => {
+    expect(myServiceInstance).to.be.instanceOf(MyService);
+  });
+
+  it('executes the initialize() at construction', () => {
+    expect(mySpec.initialize).to.be.callCount(1);
+  });
+
+  it('must contain the functions passed in the spec', () => {
+    expect('initialize' in myServiceInstance).to.be.equal(true);
+    expect('customFunction1' in myServiceInstance).to.be.equal(true);
+    expect('customFunction2' in myServiceInstance).to.be.equal(true);
+    expect('returnsThis' in myServiceInstance).to.be.equal(true);
+
+    expect(myServiceInstance.customFunction1()).to.be.equal('value1');
+    expect(myServiceInstance.customFunction2()).to.be.equal('value2');
+  });
+
+  it('must bind methods to the service instance', () => {
+    expect(myServiceInstance.returnsThis()).to.be.deep.equal(myServiceInstance);
+  });
+});

--- a/test/createService.spec.js
+++ b/test/createService.spec.js
@@ -33,10 +33,7 @@ describe('createService', () => {
   });
 
   it('must contain the functions passed in the spec', () => {
-    expect('initialize' in myServiceInstance).to.be.equal(true);
-    expect('customFunction1' in myServiceInstance).to.be.equal(true);
-    expect('customFunction2' in myServiceInstance).to.be.equal(true);
-    expect('returnsThis' in myServiceInstance).to.be.equal(true);
+    expect(myServiceInstance).to.include.all.keys('initialize', 'customFunction1', 'customFunction2', 'returnsThis');
 
     expect(myServiceInstance.customFunction1()).to.be.equal('value1');
     expect(myServiceInstance.customFunction2()).to.be.equal('value2');


### PR DESCRIPTION
# What does this PR do:
  - Converts `function ()` to `() =>` in all specs that were using them.
  - Adds a test in the `createFactory.spec.js` to test if the constructor throws an error when no app instance is provided.
  - Adds the `createService.spec.js`.

<img width="1032" alt="screen shot 2016-07-15 at 18 34 01" src="https://cloud.githubusercontent.com/assets/1002056/16881483/ba1590d0-4aba-11e6-8e50-95c2ff11ca50.png">


# Where should the reviewer start:
  - Diffs.
  - `npm test`

# Unit and/or functional tests:
All tests that were using anonymous functions were converted to arrow functions.
Added the test `test/createService.spec.js`