### PR TITLE
Adds the Provider's spec

### DIFF
--- a/test/components/Provider.spec.js
+++ b/test/components/Provider.spec.js
@@ -58,7 +58,7 @@ describe('components › Provider', function () {
     });
   });
 
-  it('calls React.Children.only() with the props.children provided', function () {
+  it('calls React.Children.only() with the props.children provided, on render', function () {
     myProviderInstance.render();
     expect(Children.only)
       .to.be.callCount(1)

--- a/test/components/Provider.spec.js
+++ b/test/components/Provider.spec.js
@@ -1,0 +1,67 @@
+/* global describe, it */
+import chai, { expect } from 'chai';
+import React, { Children, Component, PropTypes } from 'react';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import Provider from '../../src/components/Provider';
+
+const sandbox = sinon.sandbox.create();
+chai.use(sinonChai);
+
+describe('components › Provider', function () {
+  const fakeApp = {};
+  const fakeStore = {};
+  const fakeChildren = (<div id="myFakeChildren"></div>);
+  let myProviderInstance;
+
+  beforeEach(function () {
+    sandbox.spy(Children, 'only');
+    myProviderInstance = new Provider({
+      app: fakeApp,
+      children: fakeChildren,
+      store: fakeStore
+    })
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  it('extends React.Component', function () {
+    expect(Object.getPrototypeOf(Provider)).to.be.equal(Component);
+  });
+
+  it('has static propTypes defined', function () {
+    expect(Provider.propTypes).to.be.deep.equal({
+      app: PropTypes.object.isRequired,
+      children: PropTypes.element.isRequired,
+      store: PropTypes.object.isRequired
+    });
+  });
+
+  it('has static childContextTypes defined', function () {
+    expect(Provider.childContextTypes).to.be.deep.equal({
+      app: PropTypes.object.isRequired,
+      store: PropTypes.object.isRequired
+    });
+  });
+
+  it('has the app and store as private properties, just like the passed arguments', function () {
+    expect(myProviderInstance.app).to.be.deep.equal(fakeApp);
+    expect(myProviderInstance.store).to.be.deep.equal(fakeStore);
+  });
+
+  it('has a getChildContext method which returns app and store objects of the instance', function () {
+    expect(myProviderInstance.getChildContext()).to.be.deep.equal({
+      app: fakeApp,
+      store: fakeStore
+    });
+  });
+
+  it('calls React.Children.only() with the props.children provided', function () {
+    myProviderInstance.render();
+    expect(Children.only)
+      .to.be.callCount(1)
+      .and.to.be.calledWith(fakeChildren);
+  });
+});

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,4 @@
 --colors
 --compilers js:babel-register
 --require ./test/setup.js
+--recursive


### PR DESCRIPTION
# What does this PR do:
  - Changes the `test/mocha.opts` to have the `--recursive` flag which enables mocha to search through sub-folders for specs.
  - Adds the new spec `test/components/Provider.spec.js`

<img width="1090" alt="screen shot 2016-07-16 at 11 37 48" src="https://cloud.githubusercontent.com/assets/1002056/16894019/bd33c676-4b49-11e6-82e9-c15909f9de5f.png">


# Where should the reviewer start:
  - Diffs
  - `npm test`

# Unit and/or functional tests:
Added a new test `test/components/Provider.spec.js`
