### PR TITLE
Expose PropTypes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@
 * [API Reference](/docs/api/README.md)
   * [createApp](/docs/api/createApp.md)
   * [createComponent](/docs/api/createComponent.md)
+  * [PropTypes](/docs/api/PropTypes.md)
   * [combineReducers](/docs/api/combineReducers.md)
   * [createModel](/docs/api/createModel.md)
   * [createService](/docs/api/createService.md)

--- a/docs/api/Component.md
+++ b/docs/api/Component.md
@@ -1,3 +1,19 @@
 # Component
 
 Component classes ready to be embedded as JSX for rendering.
+
+## Usage
+
+```js
+import { createComponent } from 'frint';
+
+const MyComponent = createComponent({
+  render() {
+    return (
+      <p>Name is {this.prop.name}</p>
+    );
+  }
+});
+```
+
+It is best practice to define `propTypes` while defining the Component too. You can read more about it in [PropTypes](./PropTypes.md) section.

--- a/docs/api/PropTypes.md
+++ b/docs/api/PropTypes.md
@@ -1,0 +1,21 @@
+# PropTypes
+
+Same as [React.PropTypes](https://facebook.github.io/react/docs/reusable-components.html);
+
+## Usage
+
+```js
+import { createComponent, PropTypes } from 'frint';
+
+const MyComponent = createComponent({
+  propTypes: {
+    name: PropTypes.string.isRequired
+  },
+
+  render() {
+    return (
+      <p>Name is {this.props.name}</p>
+    );
+  }
+});
+```

--- a/index.js
+++ b/index.js
@@ -1,16 +1,18 @@
-const createApp = require('./lib/createApp.js');
-const createComponent = require('./lib/createComponent.js');
+const createApp = require('./lib/createApp');
+const createComponent = require('./lib/createComponent');
 const Model = require('./lib/Model');
 const createModel = require('./lib/createModel');
 const createService = require('./lib/createService');
 const createFactory = require('./lib/createFactory');
 
-const render = require('./lib/render.js');
+const render = require('./lib/render');
 
-const Region = require('./lib/components/Region.js');
+const Region = require('./lib/components/Region');
 
 const combineReducers = require('redux').combineReducers;
 const mapToProps = require('./lib/components/mapToProps');
+
+const PropTypes = require('./lib/PropTypes');
 
 module.exports = {
   createApp,
@@ -22,5 +24,6 @@ module.exports = {
   render,
   Region,
   combineReducers,
-  mapToProps
+  mapToProps,
+  PropTypes
 };

--- a/src/PropTypes.js
+++ b/src/PropTypes.js
@@ -1,0 +1,3 @@
+import { PropTypes } from 'react';
+
+export default PropTypes;

--- a/test/PropTypes.spec.js
+++ b/test/PropTypes.spec.js
@@ -1,0 +1,25 @@
+/* global describe, it */
+import chai, { expect } from 'chai';
+import PropTypes from '../src/PropTypes';
+
+describe('PropTypes', () => {
+  it('checks for existence of various types', () => {
+    expect(PropTypes.string).to.be.a('function');
+    expect(PropTypes.string.isRequired).to.be.a('function');
+
+    expect(PropTypes.node).to.be.a('function');
+    expect(PropTypes.node.isRequired).to.be.a('function');
+
+    expect(PropTypes.number).to.be.a('function');
+    expect(PropTypes.number.isRequired).to.be.a('function');
+
+    expect(PropTypes.object).to.be.a('function');
+    expect(PropTypes.object.isRequired).to.be.a('function');
+
+    expect(PropTypes.bool).to.be.a('function');
+    expect(PropTypes.bool.isRequired).to.be.a('function');
+
+    expect(PropTypes.func).to.be.a('function');
+    expect(PropTypes.func.isRequired).to.be.a('function');
+  });
+});


### PR DESCRIPTION
## What's done:

Now you can import and use PropTypes as follows:

```js
import { createComponent, PropTypes } from 'frint';

const MyComponent = createComponent({
  propTypes: {
    name: PropTypes.string.isRequired
  },

  render() {
    return (
      <p>Name is {this.props.name}</p>
    );
  }
});
```

## Unit and/or functional tests:

Yes