### PR TITLE
Pass down props from WrappedComponent into ConnectedComponent

### DIFF
--- a/src/components/mapToProps.js
+++ b/src/components/mapToProps.js
@@ -86,7 +86,7 @@ export default function mapToProps(opts = {}) {
           options.options
         )(Component);
 
-        return <ConnectedComponent />;
+        return <ConnectedComponent {...this.props} />;
       }
     });
 


### PR DESCRIPTION
This highly increases testability of frint components.

As we are creating the `ConnectedComponent` only inside the `render` method of `WrappedComponent` , there is no way from the developer's perspective, to pass down additional properties to that component, which means, we cannot stub props mapped using `mapDispatchToProps`.

For instance:

In the `MyComponent.js`
```js
const MyComponent = createComponent({
  render() {
    return(
      <Button onClick={this.props.handleClick} />
    );
  }
});

const handleClick = ...; // let's assume this is an action creator

export default mapToProps({
  dispatch: {
    handleClick,
  }
})(MyComponent);
```

so now, from you specs file, you cannot stub `handleClick` easily, as you depend on `mapToProps` to inject it for you.

With this change, you will be able to simply do this (assuming we are using `enzyme` and `Sinon.JS` and `chai` for testing):

```js
  it('should invoke my action creator', () => {
    const handleClick = sinon.spy();
    const wrapper = mount(<MyComponent handleClick />);
    wrapper.find('button').simulate('click');
    expect(handleClick).to.have.been.called.once;
  }
```

Note that with this you can pass any props from your tests and even override (`{...this.props}`) the props mapped with `mapStateToProps` or `mapAppToProps`.

Services and factories on the other hand, as they depend on the `app` and `store` being present on the `context`, we can stub them by wrapping the component under test in a component that provides a fake app and store by `getChildContext`, thus when you request a particular service or factory using `getService` or `getFactory`, the fake app would provide you with pre-configured stubs.  This will be handled by the to-be-released `frint-test` package.