### PR TITLE
Adds getValidationFunctions() method to createApp.js

### DIFF
--- a/docs/api/App.md
+++ b/docs/api/App.md
@@ -76,6 +76,12 @@ childApp.setRegion('sidebar');
 
 Returns a list of child apps, by a specific region. Returns all the child apps, irrespective of their region, if no `regionName` is provided.
 
+### getValidationFunctions()
+
+Returns a list of validation functions, passed via options to the app, to be used with the Validation service.
+
+This method attempts to obtain the list from the RootApp's options. If not available will try to obtain it from the options of the app calling it. Returns undefined in case everything fails.
+
 ### observeWidgets()
 
 Returns an observable, that you can subscribe to. Emit's a `next` event every time there is a change in the list of registered widgets.

--- a/docs/api/createComponent.md
+++ b/docs/api/createComponent.md
@@ -36,11 +36,6 @@ const MyComponent = createComponent({
 });
 ```
 
-### getDOMElement
-
-This method returns the topmost HTMLElement of your component's DOM tree. In case you don't have any DOM tree rendered,
-it will return `null`.
-
 
 ## Lifecycle events
 

--- a/src/createApp.js
+++ b/src/createApp.js
@@ -291,6 +291,23 @@ export default function createApp(options = {}) {
 
       return null;
     }
+
+    /**
+     * Attempts to get the option 'validationFunctions' from the RootApp.
+     * If it's not possible, returns from the current app as a fallback
+     *
+     * @method getValidationFunctions
+     * @return {Array|undefined} List of functions
+     * @public
+     */
+    getValidationFunctions() {
+      const rootApp = this.getRootApp();
+      if (rootApp && rootApp.getOption('validationFunctions')) {
+        return rootApp.getOption('validationFunctions');
+      }
+
+      return this.getOption('validationFunctions');
+    }
   }
 
   return App;

--- a/src/createComponent.js
+++ b/src/createComponent.js
@@ -35,16 +35,5 @@ export default function createComponent(options = {}) {
 
       return null;
     },
-
-    /**
-     * Returns the root HTML element of the component.
-     *
-     * @method getDOMElement
-     * @return {HTMLElement|null} Returns the component's root HTML Node.
-     * @public
-     */
-    getDOMElement() {
-      return ReactDOM.findDOMNode(this);
-    },
   });
 }

--- a/test/createApp.spec.js
+++ b/test/createApp.spec.js
@@ -4,6 +4,14 @@ import { expect } from 'chai';
 import createApp from '../src/createApp';
 
 describe('createApp', () => {
+  beforeEach(() => {
+    window.app = null;
+  });
+
+  afterEach(() => {
+    delete window.app;
+  });
+
   it('creates an instance', () => {
     const App = createApp({
       name: 'MyAppName',
@@ -33,7 +41,6 @@ describe('createApp', () => {
     expect(app.getValidationFunctions()).to.eql(expectedValidationFunctions);
   });
 
-
   it('creates a RootApp instance with a validationFunctions option and a ChildApp returns them via getValidationFunctions()', () => {
     const expectedValidationFunctions = ['expectedValue'];
     const unExpectedValidationFunctions = ['unExpectedValue'];
@@ -62,6 +69,32 @@ describe('createApp', () => {
 
     expect(rootApp.getValidationFunctions()).to.eql(expectedValidationFunctions);
     expect(childApp.getValidationFunctions()).to.eql(expectedValidationFunctions);
+  });
+
+  it('creates a RootApp instance without a validationFunctions option and so as the ChildApp. Expects undefined when calling getValidationFunctions()', () => {
+    const RootApp = createApp({
+      appId: '123',
+      component: true,
+      name: 'MyRootAppName',
+    });
+    const rootApp = new RootApp();
+    window.app = rootApp;
+
+    const ChildApp = createApp({
+      appId: '234',
+      component: true,
+      name: 'MyChildAppName',
+    });
+    const childApp = new ChildApp();
+
+
+    expect(rootApp).to.be.instanceof(RootApp);
+    expect(window.app).to.eql(rootApp);
+
+    expect(childApp).to.be.instanceof(ChildApp);
+
+    expect(rootApp.getValidationFunctions()).to.eql(undefined);
+    expect(childApp.getValidationFunctions()).to.eql(undefined);
 
     delete window.app;
   });

--- a/test/createApp.spec.js
+++ b/test/createApp.spec.js
@@ -16,4 +16,53 @@ describe('createApp', () => {
     expect(app).to.be.instanceof(App);
     expect(app.getOption('name')).to.eql('MyAppName');
   });
+
+
+  it('creates an instance with a validationFunctions option and returns it via getValidationFunctions()', () => {
+    const expectedValidationFunctions = ['expectedValue'];
+    const App = createApp({
+      appId: '123',
+      component: true,
+      name: 'MyAppName',
+      validationFunctions: expectedValidationFunctions,
+    });
+
+    const app = new App();
+
+    expect(app).to.be.instanceof(App);
+    expect(app.getValidationFunctions()).to.eql(expectedValidationFunctions);
+  });
+
+
+  it('creates a RootApp instance with a validationFunctions option and a ChildApp returns them via getValidationFunctions()', () => {
+    const expectedValidationFunctions = ['expectedValue'];
+    const unExpectedValidationFunctions = ['unExpectedValue'];
+    const RootApp = createApp({
+      appId: '123',
+      component: true,
+      name: 'MyRootAppName',
+      validationFunctions: expectedValidationFunctions,
+    });
+    const rootApp = new RootApp();
+    window.app = rootApp;
+
+    const ChildApp = createApp({
+      appId: '234',
+      component: true,
+      name: 'MyChildAppName',
+      validationFunctions: unExpectedValidationFunctions
+    });
+    const childApp = new ChildApp();
+
+
+    expect(rootApp).to.be.instanceof(RootApp);
+    expect(window.app).to.eql(rootApp);
+
+    expect(childApp).to.be.instanceof(ChildApp);
+
+    expect(rootApp.getValidationFunctions()).to.eql(expectedValidationFunctions);
+    expect(childApp.getValidationFunctions()).to.eql(expectedValidationFunctions);
+
+    delete window.app;
+  });
 });

--- a/test/createComponent.spec.js
+++ b/test/createComponent.spec.js
@@ -37,18 +37,13 @@ describe('createComponent', () => {
         myCustomFunction: mySpec.myCustomFunction,
         render: mySpec.render,
         componentDidMount: sinon.match.func,
-        componentWillUnmount: sinon.match.func,
-        getDOMElement: sinon.match.func
+        componentWillUnmount: sinon.match.func
       });
   });
 
   it('is a valid React component and a MyComponent\'s instance', () => {
     expect('isReactComponent' in Object.getPrototypeOf(myComponentInstance)).to.be.equal(true);
     expect(myComponentInstance).to.be.instanceof(MyComponent);
-  });
-
-  it('gets the DOM Node when executing getDOMElement()', () => {
-    expect(myComponentInstance.getDOMElement()).to.be.equal(document.querySelector('#root .test'));
   });
 
   it('has the spec\'s functions', () => {


### PR DESCRIPTION
# What does this PR do:

Adds the method `getValidationFunctions()` to `createApp.js`

Removes the method `getDOMElement()` from `createComponent.js`

![screen shot 2016-08-16 at 12 40 20](https://cloud.githubusercontent.com/assets/1002056/17696470/d1d2e8aa-63ae-11e6-94dc-38cff8b66082.png)


# Where should the reviewer start:
  - Diffs
  - `npm run test`

# Unit and/or functional tests:
- 3 tests added to `createApp.spec.js`
- 1 test removed from `createComponent.spec.js`