### PR TITLE
Fixes Region to differentiate widgets with the same name but different appNames

### DIFF
--- a/src/components/Region.js
+++ b/src/components/Region.js
@@ -56,6 +56,7 @@ export default React.createClass({
               return;
             }
 
+            const appName = widget.getOption('appName');
             const widgetName = widget.getOption('name');
 
             // @TODO: later re-implement this check with observables
@@ -69,7 +70,7 @@ export default React.createClass({
             }
 
             const existsInState = this.state.listForRendering.some((item) => {
-              return item.name === widgetName;
+              return (item.appName === appName) && (item.name === widgetName);
             });
 
             if (existsInState) {
@@ -96,8 +97,9 @@ export default React.createClass({
             });
 
             const listForRendering = [...this.state.listForRendering, {
-              name: widgetName,
+              appName,
               Component: WrapperComponent,
+              name: widgetName,
             }];
 
             this.setState({ listForRendering });
@@ -131,10 +133,10 @@ export default React.createClass({
     return (
       <div>
         {listForRendering.map((item) => {
-          const { Component, name } = item;
+          const { appName, Component, name } = item;
 
           return (
-            <Component key={name} />
+            <Component key={`${appName}_${name}`} />
           );
         })}
       </div>

--- a/test/components/Region.spec.js
+++ b/test/components/Region.spec.js
@@ -1,17 +1,11 @@
 /* global afterEach, beforeEach, describe, it, window, document */
-import chai, { expect } from 'chai';
-import React, { Children, Component, PropTypes } from 'react';
-import ReactDOM from 'react-dom';
-import sinon from 'sinon';
-import sinonChai from 'sinon-chai';
+import { expect } from 'chai';
+import React from 'react';
 
 import createApp from '../../src/createApp';
 import createComponent from '../../src/createComponent';
 import Region from '../../src/components/Region';
 import render from '../../src/render';
-
-const sandbox = sinon.sandbox.create();
-chai.use(sinonChai);
 
 describe('components › Region', () => {
   function generateCoreAppTemplate(appOptions = {}, regionName) {

--- a/test/components/Region.spec.js
+++ b/test/components/Region.spec.js
@@ -1,0 +1,92 @@
+/* global afterEach, beforeEach, describe, it, window, document */
+import chai, { expect } from 'chai';
+import React, { Children, Component, PropTypes } from 'react';
+import ReactDOM from 'react-dom';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+
+import createApp from '../../src/createApp';
+import createComponent from '../../src/createComponent';
+import Region from '../../src/components/Region';
+import render from '../../src/render';
+
+const sandbox = sinon.sandbox.create();
+chai.use(sinonChai);
+
+describe('components › Region', () => {
+  function generateCoreAppTemplate(appOptions = {}, regionName) {
+    const MyCoreComponent = createComponent({
+      render() { return <Region name={regionName} />; }
+    });
+
+    const MyCoreApp = createApp({
+      appId: '123',
+      name: 'myAppName',
+      component: MyCoreComponent
+    });
+
+    return new MyCoreApp(appOptions);
+  }
+
+  function generateWidgetAppTemplate(appName, widgetName, regionToSetTo) {
+    const MyWidgetComponent = createComponent({
+      render() { return (<div className="myWidgetComponent">{appName} - {widgetName}</div>); }
+    });
+
+    const MyWidgetApp = createApp({
+      appId: appName,
+      appName: appName,
+      name: widgetName,
+      component: MyWidgetComponent
+    });
+
+    const myWidgetAppInstance = new MyWidgetApp();
+
+    myWidgetAppInstance.setRegion(regionToSetTo);
+
+    return myWidgetAppInstance;
+  }
+
+  afterEach(() => {
+    delete window.app;
+    document.getElementById('root').innerHTML = '';
+  });
+
+  it('fails to mount when the "name" prop is missing (unable to set observable)', () => {
+    window.app = generateCoreAppTemplate();
+    expect(() => render(window.app, document.getElementById('root'))).to.throw(TypeError);
+  });
+
+  it('renders properly the region and renders a widget on it', () => {
+    window.app = generateCoreAppTemplate(undefined, 'myRegionName');
+    render(window.app, document.getElementById('root'));
+
+    generateWidgetAppTemplate('app1', 'myWidgetName', 'myRegionName');
+    expect(document.querySelectorAll('#root .myWidgetComponent').length).to.be.eql(1);
+    expect(document.querySelector('#root .myWidgetComponent').textContent).to.be.eql('app1 - myWidgetName');
+  });
+
+  it('renders properly the region and renders two widgets on it', () => {
+    window.app = generateCoreAppTemplate(undefined, 'myRegionName');
+    render(window.app, document.getElementById('root'));
+
+    generateWidgetAppTemplate('app1', 'myWidgetName1', 'myRegionName');
+    generateWidgetAppTemplate('app2', 'myWidgetName2', 'myRegionName');
+
+    expect(document.querySelectorAll('#root .myWidgetComponent').length).to.be.eql(2);
+    expect(document.querySelectorAll('#root .myWidgetComponent')[0].textContent).to.be.eql('app1 - myWidgetName1');
+    expect(document.querySelectorAll('#root .myWidgetComponent')[1].textContent).to.be.eql('app2 - myWidgetName2');
+  });
+
+  it('renders properly the region and renders two widgets on it, with the same name and different appNames', () => {
+    window.app = generateCoreAppTemplate(undefined, 'myRegionName');
+    render(window.app, document.getElementById('root'));
+
+    generateWidgetAppTemplate('app1', 'myWidgetName', 'myRegionName');
+    generateWidgetAppTemplate('app2', 'myWidgetName', 'myRegionName');
+
+    expect(document.querySelectorAll('#root .myWidgetComponent').length).to.be.eql(2);
+    expect(document.querySelectorAll('#root .myWidgetComponent')[0].textContent).to.be.eql('app1 - myWidgetName');
+    expect(document.querySelectorAll('#root .myWidgetComponent')[1].textContent).to.be.eql('app2 - myWidgetName');
+  });
+});


### PR DESCRIPTION
# What does this PR do:
When two different apps with the same widget name tried to render in the same Region, only one was rendered.

E.g.

myFirstApp - helloWorldWidget
mySecondApp - helloWorldWidget

This PR fixes that.

(Proof)
![screen shot 2016-09-01 at 23 09 09](https://cloud.githubusercontent.com/assets/1002056/18184412/46cf02be-7099-11e6-9169-030970b5d182.png)


# Where should the reviewer start:
  - Diffs
  - With the current master, try to create 2 widgets with the same name and different appNames and target the same region. Only 1 will render. The other one will be assumed as rendered (due to [this previous check](https://github.com/Travix-International/frint/compare/fix-region-to-differentiate-apps-with-same-name?expand=1#diff-fbd171f24f3d6b7eb868c635ff42166eL72)).

# Unit and/or functional tests:
Tests were added for `components/Region.js`.