### PR TITLE
Fix: for passing initial shared state across Widgets

### DIFF
--- a/src/components/mapToProps.js
+++ b/src/components/mapToProps.js
@@ -24,6 +24,10 @@ export default function mapToProps(opts = {}) {
 
   return (Component) => {
     const WrappedComponent = React.createClass({
+      displayName: (typeof Component.displayName !== 'undefined')
+        ? `mapToProps(${Component.displayName})`
+        : 'mapToProps',
+
       getInitialState() {
         return {
           mappedAppToProps: {},

--- a/src/components/mapToProps.js
+++ b/src/components/mapToProps.js
@@ -44,7 +44,7 @@ export default function mapToProps(opts = {}) {
         this.context.app.readableApps.forEach((readableAppName) => {
           const readableAppStore = this.context.app.getStore(readableAppName);
 
-          function generateUpdatedState() {
+          const generateUpdatedState = () => {
             const currentState = this.state;
             const readableStores = this.state.readableStores;
 
@@ -55,7 +55,7 @@ export default function mapToProps(opts = {}) {
                 [readableAppName]: readableAppStore.getState(),
               },
             };
-          }
+          };
 
           this.replaceState({
             ...generateUpdatedState()

--- a/src/components/mapToProps.js
+++ b/src/components/mapToProps.js
@@ -40,19 +40,27 @@ export default function mapToProps(opts = {}) {
         this.context.app.readableApps.forEach((readableAppName) => {
           const readableAppStore = this.context.app.getStore(readableAppName);
 
-          this.storeSubscriptions[readableAppName] = readableAppStore.subscribe(() => {
+          function generateUpdatedState() {
             const currentState = this.state;
             const readableStores = this.state.readableStores;
 
-            const updatedState = {
+            return {
               ...currentState,
               readableStores: {
                 ...readableStores,
                 [readableAppName]: readableAppStore.getState(),
               },
             };
+          }
 
-            this.replaceState(updatedState);
+          this.replaceState({
+            ...generateUpdatedState()
+          });
+
+          this.storeSubscriptions[readableAppName] = readableAppStore.subscribe(() => {
+            this.replaceState({
+              ...generateUpdatedState()
+            });
           });
         });
 

--- a/src/createApp.js
+++ b/src/createApp.js
@@ -27,6 +27,7 @@ class BaseApp {
       store: null,
       reducer: (state = {}) => state,
       initialState: {},
+      enableLogger: true,
 
       services: {},
       factories: {},
@@ -115,9 +116,11 @@ class BaseApp {
     ];
 
     if (process.env.NODE_ENV !== 'production') {
-      const createLogger = require('redux-logger'); // eslint-disable-line
+      if (this.getOption('enableLogger') === true) {
+        const createLogger = require('redux-logger'); // eslint-disable-line
 
-      middlewares.push(createLogger());
+        middlewares.push(createLogger());
+      }
     }
 
     this.options.store = createStore(

--- a/test/components/mapToProps.spec.js
+++ b/test/components/mapToProps.spec.js
@@ -1,0 +1,167 @@
+/* global afterEach, beforeEach, describe, it, window, document */
+import { expect } from 'chai';
+import React from 'react';
+
+import createApp from '../../src/createApp';
+import createComponent from '../../src/createComponent';
+import render from '../../src/render';
+import { combineReducers } from '../../src';
+import mapToProps from '../../src/components/mapToProps';
+
+describe('components › mapToProps', () => {
+  afterEach(() => {
+    delete window.app;
+    document.getElementById('root').innerHTML = '';
+  });
+
+  it('is a function', function () {
+    expect(mapToProps).to.be.a('function');
+  });
+
+  it('returns a function, returning a Component', function () {
+    const TestComponent = createComponent({
+      displayName: 'TestComponent',
+
+      render() {
+        return null;
+      }
+    });
+
+    const Container = mapToProps()(TestComponent);
+    expect(Container).to.be.a('function');
+    expect(Container.displayName).to.equal('mapToProps(TestComponent)');
+    expect(Container.contextTypes).to.exist; // eslint-disable-line
+  });
+
+  describe('Basic', function () {
+    const TestComponent = createComponent({
+      render() {
+        return (
+          <div>
+            <p className="appId">{this.props.appId}</p>
+            <p className="text">Hello World</p>
+          </div>
+        );
+      }
+    });
+    const TestRootComponent = mapToProps({
+      app(app) {
+        return {
+          appId: app.getOption('appId')
+        };
+      }
+    })(TestComponent);
+    const TestApp = createApp({
+      appId: 'test',
+      component: TestRootComponent
+    });
+
+    it('creates container from component', function () {
+      expect(TestRootComponent).to.be.a('function');
+      expect(TestRootComponent.displayName).to.be.a('string');
+
+      const app = new TestApp();
+      render(app, document.getElementById('root'));
+
+      const text = document.querySelector('#root .text');
+      expect(text.innerHTML).to.equal('Hello World');
+    });
+
+    it('maps from App instance to props', function () {
+      const app = new TestApp({
+        appId: 'customAppIdHere'
+      });
+      render(app, document.getElementById('root'));
+
+      const text = document.querySelector('#root .appId');
+      expect(text.innerHTML).to.equal('customAppIdHere');
+    });
+  });
+
+  describe('Dispatchable actions and state', function () {
+    const INCREMENT_COUNTER = 'INCREMENT_COUNTER';
+    const DECREMENT_COUNTER = 'DECREMENT_COUNTER';
+
+    const INITIAL_STATE = {
+      value: 10
+    };
+
+    function counterReducer(state = INITIAL_STATE, action) {
+      switch (action.type) {
+        case INCREMENT_COUNTER:
+          return Object.assign({}, {
+            value: state.value + 1
+          });
+
+        case DECREMENT_COUNTER:
+          return Object.assign({}, {
+            value: state.value - 1
+          });
+
+        default:
+          return state;
+      }
+    }
+
+    const testRootReducer = combineReducers({
+      counter: counterReducer
+    });
+
+    function incrementCounter() {
+      return { type: INCREMENT_COUNTER };
+    }
+
+    function decrementCounter() {
+      return { type: DECREMENT_COUNTER };
+    }
+
+    const TestComponent = createComponent({
+      render() {
+        return (
+          <div>
+            <a className="add" onClick={() => this.props.incrementCounter()}>Add</a>
+            <a className="subtract" onClick={() => this.props.decrementCounter()}>Subtract</a>
+            <p className="counter">{this.props.counter}</p>
+          </div>
+        );
+      }
+    });
+
+    const TestRootComponent = mapToProps({
+      dispatch: {
+        incrementCounter,
+        decrementCounter
+      },
+      state(state) {
+        return {
+          counter: state.counter.value
+        };
+      }
+    })(TestComponent);
+
+    const TestApp = createApp({
+      appId: 'Test',
+      reducer: testRootReducer,
+      component: TestRootComponent,
+      enableLogger: false
+    });
+
+    it('renders with initial state', function () {
+      const app = new TestApp();
+      render(app, document.getElementById('root'));
+
+      expect(document.querySelector('#root .counter').innerHTML).to.equal('10');
+    });
+
+    it('re-renders with updated state upon dispatched actions', function () {
+      const app = new TestApp();
+      render(app, document.getElementById('root'));
+
+      document.querySelector('#root .add').click(); // 11
+      document.querySelector('#root .add').click(); // 12
+      document.querySelector('#root .subtract').click(); // 11
+
+      expect(document.querySelector('#root .counter').innerHTML).to.equal('11');
+    });
+  });
+});

--- a/test/components/mapToProps.spec.js
+++ b/test/components/mapToProps.spec.js
@@ -2,11 +2,15 @@
 import { expect } from 'chai';
 import React from 'react';
 
-import createApp from '../../src/createApp';
-import createComponent from '../../src/createComponent';
-import render from '../../src/render';
-import { combineReducers } from '../../src';
-import mapToProps from '../../src/components/mapToProps';
+import {
+  createApp,
+  createComponent,
+  combineReducers,
+  render,
+  createService,
+  createFactory,
+  mapToProps
+} from '../../src';
 
 describe('components › mapToProps', () => {
   afterEach(() => {
@@ -33,27 +37,55 @@ describe('components › mapToProps', () => {
     expect(Container.contextTypes).to.exist; // eslint-disable-line
   });
 
-  describe('Basic', function () {
+  describe('Injection', function () {
     const TestComponent = createComponent({
       render() {
         return (
           <div>
             <p className="appId">{this.props.appId}</p>
             <p className="text">Hello World</p>
+            <p className="serviceName">{this.props.foo.getName()}</p>
+            <p className="factoryName">{this.props.bar.getName()}</p>
           </div>
         );
       }
     });
+
     const TestRootComponent = mapToProps({
       app(app) {
         return {
           appId: app.getOption('appId')
         };
+      },
+      services: {
+        foo: 'foo'
+      },
+      factories: {
+        bar: 'bar'
       }
     })(TestComponent);
+
+    const TestFooService = createService({
+      getName() {
+        return 'TestService';
+      }
+    });
+
+    const TestBarFactory = createFactory({
+      getName() {
+        return 'TestFactory';
+      }
+    });
+
     const TestApp = createApp({
       appId: 'test',
-      component: TestRootComponent
+      component: TestRootComponent,
+      services: {
+        foo: TestFooService
+      },
+      factories: {
+        bar: TestBarFactory
+      }
     });
 
     it('creates container from component', function () {
@@ -75,6 +107,22 @@ describe('components › mapToProps', () => {
 
       const text = document.querySelector('#root .appId');
       expect(text.innerHTML).to.equal('customAppIdHere');
+    });
+
+    it('maps from Service to props', function () {
+      const app = new TestApp();
+      render(app, document.getElementById('root'));
+
+      const text = document.querySelector('#root .serviceName');
+      expect(text.innerHTML).to.equal('TestService');
+    });
+
+    it('maps from Factory to props', function () {
+      const app = new TestApp();
+      render(app, document.getElementById('root'));
+
+      const text = document.querySelector('#root .factoryName');
+      expect(text.innerHTML).to.equal('TestFactory');
     });
   });
 

--- a/test/components/mapToProps.spec.js
+++ b/test/components/mapToProps.spec.js
@@ -1,4 +1,4 @@
-/* global afterEach, beforeEach, describe, it, window, document */
+/* global afterEach, beforeEach, describe, it, window, document, before, resetDOM */
 import { expect } from 'chai';
 import React from 'react';
 
@@ -14,6 +14,10 @@ import {
 } from '../../src';
 
 describe('components › mapToProps', () => {
+  before(function () {
+    resetDOM();
+  });
+
   afterEach(() => {
     delete window.app;
     document.getElementById('root').innerHTML = '';

--- a/test/components/mapToProps.spec.js
+++ b/test/components/mapToProps.spec.js
@@ -9,6 +9,7 @@ import {
   render,
   createService,
   createFactory,
+  Region,
   mapToProps
 } from '../../src';
 
@@ -210,6 +211,155 @@ describe('components › mapToProps', () => {
       document.querySelector('#root .subtract').click(); // 11
 
       expect(document.querySelector('#root .counter').innerHTML).to.equal('11');
+    });
+  });
+
+  describe('Shared state', function () {
+    // Core App
+    const CoreComponent = createComponent({
+      render() {
+        return (
+          <div>
+            <Region name="main" />
+            <Region name="sidebar" />
+          </div>
+        );
+      }
+    });
+
+    const CoreApp = createApp({
+      appId: 'TestCore',
+      component: CoreComponent
+    });
+
+    // Widget #1: Foo
+    const FOO_INCREMENT_COUNTER = 'FOO_INCREMENT_COUNTER';
+
+    function fooIncrementCounter() {
+      return { type: FOO_INCREMENT_COUNTER };
+    }
+
+    const FOO_INITIAL_STATE = {
+      value: 10
+    };
+
+    function fooCounterReducer(state = FOO_INITIAL_STATE, action) {
+      switch (action.type) {
+        case FOO_INCREMENT_COUNTER:
+          return Object.assign({}, {
+            value: state.value + 1
+          });
+
+        default:
+          return state;
+      }
+    }
+
+    const fooRootReducer = combineReducers({
+      counter: fooCounterReducer
+    });
+
+    const FooComponent = createComponent({
+      render() {
+        return (
+          <div className="foo">
+            <p className="text">Hello World from Foo</p>
+            <p className="counter">{this.props.counter}</p>
+            <a className="add" onClick={() => this.props.incrementCounter()}>Add</a>
+          </div>
+        );
+      }
+    });
+
+    const FooRootComponent = mapToProps({
+      dispatch: {
+        incrementCounter: fooIncrementCounter
+      },
+      state(state) {
+        return {
+          counter: state.counter.value
+        };
+      }
+    })(FooComponent);
+
+    const FooApp = createApp({
+      appId: 'TestFooId',
+      name: 'testFoo',
+      component: FooRootComponent,
+      reducer: fooRootReducer,
+      enableLogger: false
+    });
+
+    // Widget #2: Bar
+    const BarComponent = createComponent({
+      render() {
+        return (
+          <div className="bar">
+            <p className="text">Hello World from Bar</p>
+            <p className="counter">{this.props.counter}</p>
+          </div>
+        );
+      }
+    });
+
+    const BarRootComponent = mapToProps({
+      shared(sharedState) {
+        return {
+          counter: (
+            typeof sharedState.testFoo !== 'undefined' &&
+            typeof sharedState.testFoo.counter !== 'undefined'
+          )
+            ? sharedState.testFoo.counter.value
+            : 'n/a',
+          sharedWasCalled: true
+        };
+      }
+    })(BarComponent);
+
+    const BarApp = createApp({
+      appId: 'TestBarId',
+      name: 'testBar',
+      component: BarRootComponent
+    });
+
+    it('renders Widget Bar, with Foo\'s initial state', function () {
+      window.app = new CoreApp();
+      render(window.app, document.getElementById('root'));
+
+      const fooApp = new FooApp();
+      fooApp.setRegion('main');
+
+      const barApp = new BarApp();
+      barApp.readStateFrom(['testFoo']);
+      barApp.setRegion('sidebar');
+
+      expect(document.querySelector('#root .foo .text').innerHTML).to.equal('Hello World from Foo');
+      expect(document.querySelector('#root .foo .counter').innerHTML).to.equal('10');
+
+      expect(document.querySelector('#root .bar .text').innerHTML).to.equal('Hello World from Bar');
+      expect(document.querySelector('#root .bar .counter').innerHTML).to.equal('10');
+    });
+
+    it('re-renders Widget Bar, with Foo\'s updated state', function () {
+      window.app = new CoreApp();
+      render(window.app, document.getElementById('root'));
+
+      const fooApp = new FooApp();
+      fooApp.setRegion('main');
+
+      const barApp = new BarApp();
+      barApp.readStateFrom(['testFoo']);
+      barApp.setRegion('sidebar');
+
+      expect(document.querySelector('#root .foo .text').innerHTML).to.equal('Hello World from Foo');
+      expect(document.querySelector('#root .foo .counter').innerHTML).to.equal('10');
+
+      document.querySelector('#root .foo .add').click();
+      document.querySelector('#root .foo .add').click();
+      expect(document.querySelector('#root .foo .counter').innerHTML).to.equal('12');
+
+      expect(document.querySelector('#root .bar .text').innerHTML).to.equal('Hello World from Bar');
+      expect(document.querySelector('#root .bar .counter').innerHTML).to.equal('12');
     });
   });
 });

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,6 +1,10 @@
 import { jsdom } from 'jsdom';
 
-global.document = jsdom('<html><body><div id="root"></div></body></html>');
-global.window = global.document.defaultView;
-global.location = global.window.location;
-global.navigator = { userAgent: 'node.js' };
+global.resetDOM = function resetDOM() {
+  global.document = jsdom('<html><body><div id="root"></div></body></html>');
+  global.window = global.document.defaultView;
+  global.location = global.window.location;
+  global.navigator = { userAgent: 'node.js' };
+};
+
+global.resetDOM();


### PR DESCRIPTION
## The bug

To reproduce: 

* Create Widget `A` and `B`
* `B` wants to read state of `A`
* When `B`'s container component is rendered, it doesn't have the state from `A` **initially**
* Only after a new action has been fired in `A`'s store, `B` gets the state right way

## The fix

* Instead of only updating the state from inside the subscription, we are now passing the state initially too, to make sure it is available to Container components at all times.

---

## Additional changes

* A new `resetDOM` function in tests to clear globals in mocha
* Unit tests for `mapToProps` function
* Coverage increased from 64% to **83%**