### PR TITLE
Trigger `initialize()` method in Service and Factory with constructor options

### DIFF
--- a/docs/api/createService.md
+++ b/docs/api/createService.md
@@ -25,7 +25,8 @@ you can use the lifecycle method `initialize()`.
 import { createService } from 'frint';
 
 export default createService({
-  initialize() {
+  initialize(options = {}) {
+    // `options` contains all constructor options
     this.myProp = 'something';
   },
   myMethod() {

--- a/src/createService.js
+++ b/src/createService.js
@@ -16,7 +16,7 @@ export default function createService(extend = {}) {
         .forEach((prop) => (this[prop] = this[prop].bind(this)));
 
       if (typeof this.initialize === 'function') {
-        this.initialize();
+        this.initialize(options);
       }
     }
   }

--- a/test/createFactory.spec.js
+++ b/test/createFactory.spec.js
@@ -32,4 +32,22 @@ describe('createFactory', () => {
     expect('myCustomFunction' in myFactoryInstance).to.be.equal(true);
     expect(myFactoryInstance.myCustomFunction()).to.be.equal('value');
   });
+
+  it('triggers initialize method with constructor options', () => {
+    const TestFactory = createFactory({
+      initialize(options) {
+        this.storedOptions = options;
+      }
+    });
+
+    const testFactoryInstance = new TestFactory({
+      app: true,
+      foo: 'bar'
+    });
+
+    expect(testFactoryInstance.storedOptions).to.deep.equal({
+      app: true,
+      foo: 'bar'
+    });
+  });
 });

--- a/test/createService.spec.js
+++ b/test/createService.spec.js
@@ -42,4 +42,22 @@ describe('createService', () => {
   it('must bind methods to the service instance', () => {
     expect(myServiceInstance.returnsThis()).to.be.deep.equal(myServiceInstance);
   });
+
+  it('triggers initialize method with constructor options', () => {
+    const TestService = createService({
+      initialize(options) {
+        this.storedOptions = options;
+      }
+    });
+
+    const testServiceInstance = new TestService({
+      app: true,
+      foo: 'bar'
+    });
+
+    expect(testServiceInstance.storedOptions).to.deep.equal({
+      app: true,
+      foo: 'bar'
+    });
+  });
 });


### PR DESCRIPTION
## Current behavior

* In Services and Factories, we check if an `initialize` method is available or not
* If available, we execute that during the class construction phase without any arguments

```js
const MyFactory = createFactory({
  initialize() {
    // doSomething()
  }
});
```

## Updated behavior

* Now when executing the `initialize()` method, we are passing the constructor options as arguments too

```js
const MyFactory = createFactory({
  initialize(options) {
    // `options.app` === app
  }
});
```

## Why?

It is very handy while unit testing, and make assertions based on what options were passed to the Factory (or Service) during construction easier to tackle. I ran into it while writing tests for a new `Logger` Factory (internally uses `travix-logger` package).