### PR TITLE
App: new `setRegions` method

### DIFF
--- a/docs/api/App.md
+++ b/docs/api/App.md
@@ -72,6 +72,14 @@ To be called from the child-app, for setting its region in the parent app.
 childApp.setRegion('sidebar');
 ```
 
+### setRegions(regionNames)
+
+Similar to `setRegion`, but accepts an array of multiple region names:
+
+```js
+childApp.setRegions(['sidebar', 'footer']);
+```
+
 ### getWidgets(regionName)
 
 Returns a list of child apps, by a specific region. Returns all the child apps, irrespective of their region, if no `regionName` is provided.

--- a/src/createApp.js
+++ b/src/createApp.js
@@ -165,12 +165,12 @@ class BaseApp {
     return this.options[key];
   }
 
-  registerWidget(WidgetApp, regionName) {
+  registerWidget(widgetApp, regionName) {
     if (!Array.isArray(this.widgetsByRegion[regionName])) {
       this.widgetsByRegion[regionName] = [];
     }
 
-    this.widgetsByRegion[regionName].push(WidgetApp);
+    this.widgetsByRegion[regionName].push(widgetApp);
 
     return this.widgetsSubject.next(this.widgetsByRegion);
   }
@@ -205,13 +205,19 @@ class BaseApp {
    * by doing Widget.setRegion()
    */
   setRegion(regionName) {
+    return this.setRegions([regionName]);
+  }
+
+  setRegions(regionNames) {
     const rootApp = this.getRootApp();
 
     if (!rootApp) {
       throw new Error('No root app instance available, so cannot set region.');
     }
 
-    return rootApp.registerWidget(this, regionName);
+    return regionNames.forEach((regionName) => {
+      return rootApp.registerWidget(this, regionName);
+    });
   }
 
   getWidgets(regionName = null) {

--- a/test/createApp.spec.js
+++ b/test/createApp.spec.js
@@ -212,6 +212,17 @@ describe('createApp', function () {
     expect(window.app.getStore('blah')).to.equal(null);
   });
 
+  it('sets multiple regions for a widget', function () {
+    window.app = new CoreApp();
+
+    const widget = new WidgetApp();
+
+    widget.setRegions(['header', 'footer']);
+
+    expect(window.app.getWidgets('header')).to.deep.equal([widget]);
+    expect(window.app.getWidgets('footer')).to.deep.equal([widget]);
+  });
+
   it('throws error if setRegion is called without a root app', function () {
     const widget = new WidgetApp();
 


### PR DESCRIPTION
## What's done
- Introduced new `setRegions` method, accepting multiple Region names
- Existing `setRegion` still exists, and calls `setRegions` internally.

Note: not a breaking change. done mainly to be more in line with the `app.manifest` file, which stores the region names as an array under `targetContainers` key.
