### PR TITLE
Server-side rendering

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,8 @@
   * [Component](/docs/api/Component.md)
   * [mapToProps](/docs/api/mapToProps.md)
   * [Region](/docs/api/Region.md)
+  * [server](/docs/api/server/README.md)
+    * [renderToString](/docs/api/server/renderToString.md)
 * [Glossary](/docs/Glossary.md)
 * [FAQ](/docs/faq.md)
 * [Contributing](/CONTRIBUTING.md)

--- a/docs/api/server/README.md
+++ b/docs/api/server/README.md
@@ -1,0 +1,13 @@
+# server
+
+Functions exposed are only available in the server-side.
+
+Can be accessed via:
+
+```js
+import frintServerSide from 'frint/lib/server';
+```
+
+## Available functions
+
+* [renderToString](./renderToString.md)

--- a/docs/api/server/renderToString.md
+++ b/docs/api/server/renderToString.md
@@ -1,0 +1,23 @@
+# renderToString
+
+Renders an App instance to a string.
+
+## Usage
+
+```js
+import { renderToString } from 'frint/lib/server';
+
+import MyApp from '../app'; // your App class
+
+const app = new MyApp();
+
+const html = renderToString(app);
+```
+
+## Arguments
+
+1. `app`: Instance of your App
+
+## Returns
+
+String of App's rendered HTML output.

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,0 +1,5 @@
+import renderToString from './renderToString';
+
+export default {
+  renderToString,
+};

--- a/src/server/renderToString.js
+++ b/src/server/renderToString.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import {
+  renderToString as reactRenderToString
+} from 'react-dom/server';
+
+export default function renderToString(app) {
+  const Component = app.render();
+
+  return reactRenderToString(<Component />);
+}

--- a/test/server/renderToString.spec.js
+++ b/test/server/renderToString.spec.js
@@ -34,8 +34,5 @@ describe('server › renderToString', function () {
 
     const html = renderToString(app);
     expect(html).to.contain('>Hello World!</p></div>');
-
-    const htmlWithoutCallbacks = renderToString(app, false);
-    expect(htmlWithoutCallbacks).to.contain('>Hello World!</p></div>');
   });
 });

--- a/test/server/renderToString.spec.js
+++ b/test/server/renderToString.spec.js
@@ -1,0 +1,41 @@
+/* global describe, it */
+import { expect } from 'chai';
+import React from 'react';
+
+import {
+  createApp,
+  createComponent
+} from '../../src';
+import renderToString from '../../src/server/renderToString';
+
+describe('server › renderToString', function () {
+  it('is a function', function () {
+    expect(renderToString).to.be.a('function');
+  });
+
+  it('returns HTML output of an App instance', function () {
+    const TestComponent = createComponent({
+      render() {
+        return (
+          <div>
+            <p>Hello World!</p>
+          </div>
+        );
+      }
+    });
+
+    const TestApp = createApp({
+      appId: 'TestAppId',
+      name: 'TestAppname',
+      component: TestComponent,
+    });
+
+    const app = new TestApp();
+
+    const html = renderToString(app);
+    expect(html).to.contain('>Hello World!</p></div>');
+
+    const htmlWithoutCallbacks = renderToString(app, false);
+    expect(htmlWithoutCallbacks).to.contain('>Hello World!</p></div>');
+  });
+});


### PR DESCRIPTION
## What's done in this PR:

New `renderToString` function has been introduced, which is available only in the server-side.

Accepts an `app` instance, and renders it to String.

**Note**: No breaking changes.

Docs and tests are in the diff.

## Example usage

```js
import { renderToString } from 'frint/lib/server';

import MyApp from '../app'; // your custom frint App class

const app = new MyApp();

const html = renderToString(app);
```