### PR TITLE
Middleware for asynchronous actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "lodash": "^4.13.1",
     "react": "^0.14.8",
     "react-dom": "^0.14.8",
-    "react-redux": "^4.4.5",
     "redux": "^3.5.2",
     "redux-logger": "^2.6.1",
     "redux-thunk": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "react-dom": "^0.14.8",
     "redux": "^3.5.2",
     "redux-logger": "^2.6.1",
-    "redux-thunk": "^2.1.0",
     "rxjs": "^5.0.0-rc.1"
   },
   "devDependencies": {

--- a/src/createApp.js
+++ b/src/createApp.js
@@ -3,9 +3,9 @@
 import { Subject } from 'rxjs';
 import React from 'react';
 import { createStore, applyMiddleware, compose } from 'redux';
-import thunk from 'redux-thunk';
 import _ from 'lodash';
 import createAppendActionMiddleware from './middlewares/appendAction';
+import createAsyncMiddleware from './middlewares/async';
 import Provider from './components/Provider';
 
 class BaseApp {
@@ -130,7 +130,7 @@ class BaseApp {
 
   _createStore(rootReducer, initialState = {}) {
     const middlewares = [
-      thunk.withExtraArgument({ app: this }),
+      createAsyncMiddleware({ app: this }),
       createAppendActionMiddleware({
         key: 'appName',
         value: this.getOption('name')

--- a/src/middlewares/async.js
+++ b/src/middlewares/async.js
@@ -1,0 +1,19 @@
+/**
+ * ES6 version of:
+ * https://github.com/gaearon/redux-thunk
+ */
+export default function (...args) {
+  return (store) => {
+    const { dispatch, getState } = store;
+
+    return (next) => {
+      return (action) => {
+        if (typeof action !== 'function') {
+          return next(action);
+        }
+
+        return action(dispatch, getState, ...args);
+      };
+    };
+  };
+}

--- a/test/components/mapToProps.spec.js
+++ b/test/components/mapToProps.spec.js
@@ -166,6 +166,7 @@ describe('components › mapToProps', function () {
     const INCREMENT_COUNTER = 'INCREMENT_COUNTER';
     const INCREMENT_COUNTER_BY_STEP = 'INCREMENT_COUNTER_BY_STEP';
     const DECREMENT_COUNTER = 'DECREMENT_COUNTER';
+    const SET_COUNTER = 'SET_COUNTER';
 
     const INITIAL_STATE = {
       value: 10
@@ -188,6 +189,11 @@ describe('components › mapToProps', function () {
             value: state.value - 1
           });
 
+        case SET_COUNTER:
+          return Object.assign({}, {
+            value: action.value
+          });
+
         default:
           return state;
       }
@@ -205,6 +211,22 @@ describe('components › mapToProps', function () {
       return { type: INCREMENT_COUNTER_BY_STEP, step };
     }
 
+    function setCounter(value) {
+      return { type: SET_COUNTER, value };
+    }
+
+    function setCounterByStepAsync(step) {
+      return (dispatch, getState, { app }) => {
+        const currentState = getState();
+
+        if (app.getOption('appId') === 'Test') {
+          const newValue = currentState.counter.value + step;
+
+          dispatch(setCounter(newValue));
+        }
+      };
+    }
+
     function decrementCounter() {
       return { type: DECREMENT_COUNTER };
     }
@@ -216,6 +238,7 @@ describe('components › mapToProps', function () {
             <a className="add" onClick={() => this.props.incrementCounter()}>Add</a>
             <a className="addByStep" onClick={() => this.props.incrementCounterByStep(5)}>Add +5</a>
             <a className="subtract" onClick={() => this.props.decrementCounter()}>Subtract</a>
+            <a className="setByStepAsync" onClick={() => this.props.setCounterByStepAsync(5)}>Set async</a>
             <p className="counter">{this.props.counter}</p>
           </div>
         );
@@ -226,6 +249,7 @@ describe('components › mapToProps', function () {
       dispatch: {
         incrementCounter,
         incrementCounterByStep,
+        setCounterByStepAsync,
         decrementCounter
       },
       state(state) {
@@ -270,6 +294,15 @@ describe('components › mapToProps', function () {
 
       document.querySelector('#root .addByStep').click(); // 15
       document.querySelector('#root .addByStep').click(); // 20
+      expect(document.querySelector('#root .counter').innerHTML).to.equal('20');
+    });
+
+    it('triggers an asynchronous action', () => {
+      const app = new TestApp();
+      render(app, document.getElementById('root'));
+
+      document.querySelector('#root .setByStepAsync').click(); // 15
+      document.querySelector('#root .setByStepAsync').click(); // 20
       expect(document.querySelector('#root .counter').innerHTML).to.equal('20');
     });
   });

--- a/test/middlewares/async.js
+++ b/test/middlewares/async.js
@@ -1,0 +1,58 @@
+/* global describe, it */
+import { expect } from 'chai';
+import createAsyncMiddleware from '../../src/middlewares/async';
+
+describe('middlewares › async', function () {
+  it('returns a function', function () {
+    expect(createAsyncMiddleware()).to.be.a('function');
+  });
+
+  it('dispatches function when returned from an action creator', function (done) {
+    const fakeStore = {
+      dispatch(payload) {
+        if (
+          payload.type === 'SECOND_ACTION' &&
+          payload.value === 20
+        ) {
+          done();
+        }
+      },
+
+      getState() {
+        return {
+          counter: 10
+        };
+      }
+    };
+
+    const fakeAppOptions = {
+      name: 'FakeApp'
+    };
+
+    const fakeApp = {
+      getOption(key) {
+        return fakeAppOptions[key];
+      }
+    };
+
+    function actualIncrementAction(step) {
+      expect(step).to.equal(5);
+
+      done();
+    }
+
+    function incrementActionAsync(step) {
+      return (dispatch, getState, { app }) => {
+        if (app.getOption('name') === 'FakeApp') {
+          return dispatch(actualIncrementAction(step));
+        }
+
+        return null;
+      };
+    }
+
+    const middleware = createAsyncMiddleware({ app: fakeApp });
+
+    middleware(fakeStore)()(incrementActionAsync(5));
+  });
+});


### PR DESCRIPTION
## What's done:

* Introduced new `async` middleware which is used internally instead of `redux-thunk`

Dependencies removed:

* `redux-thunk`: replaced by new middleware in this PR
* `react-redux`: which was already made redundant by previous PRs

**Note**: not a breaking change.

Tested both at `mapToProps` level, and also at unit level for the new middleware.