### PR TITLE
Adds greenkeeper ignore and updates .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,125 @@ lib
 
 coverage
 .nyc_output/
+
+
+### macOS ###
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+# Thumbnails
+._*
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+
+### OSX ###
+# Icon must end with two \r
+# Thumbnails
+# Files that might appear in the root of a volume
+# Directories potentially created on remote AFP share
+
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+
+
+### SublimeText ###
+# cache files for sublime text
+*.tmlanguage.cache
+*.tmPreferences.cache
+*.stTheme.cache
+
+# workspace files are user-specific
+*.sublime-workspace
+
+# project files should be checked into the repository, unless a significant
+# proportion of contributors will probably not be using SublimeText
+# *.sublime-project
+
+# sftp configuration file
+sftp-config.json
+
+# Package control specific files
+Package Control.last-run
+Package Control.ca-list
+Package Control.ca-bundle
+Package Control.system-ca-bundle
+Package Control.cache/
+Package Control.ca-certs/
+bh_unicode_properties.cache
+
+# Sublime-github package stores a github token in this file
+# https://packagecontrol.io/packages/sublime-github
+GitHub.sublime-settings
+
+
+### WebStorm ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea/workspace.xml
+.idea/tasks.xml
+
+# Sensitive or high-churn files:
+.idea/dataSources/
+.idea/dataSources.ids
+.idea/dataSources.xml
+.idea/dataSources.local.xml
+.idea/sqlDataSources.xml
+.idea/dynamic.xml
+.idea/uiDesigner.xml
+
+# Gradle:
+.idea/gradle.xml
+.idea/libraries
+
+# Mongo Explorer plugin:
+.idea/mongoSettings.xml
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+### WebStorm Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr

--- a/package.json
+++ b/package.json
@@ -1,32 +1,10 @@
 {
-  "name": "frint",
-  "version": "0.9.0",
-  "description": "Framework for building front-end apps",
-  "main": "./lib/index.js",
-  "scripts": {
-    "build": "webpack",
-    "transpile": "babel src --out-dir lib",
-    "lint": "eslint --color '{src,test}/**/*.js'",
-    "cover": "nyc --reporter=lcov --require babel-register mocha && npm run cover:report",
-    "cover:report": "nyc report",
-    "test": "npm run cover",
-    "coverage:coveralls": "cat ./coverage/lcov.info | coveralls",
-    "alex:docs": "alex",
-    "alex:code": "for file in $(find . -path ./node_modules -prune -o -name '*.js' -print); do echo \"\nchecking $file:\" && cat $file | ./node_modules/.bin/alex; done",
-    "alex": "npm run alex:docs && npm run alex:code",
-    "docs:prepare": "gitbook install",
-    "docs:clean": "rimraf _book",
-    "docs:build": "npm run docs:prepare && gitbook build -g Travix-International/frint",
-    "docs:watch": "npm run docs:prepare && gitbook serve",
-    "docs:publish": "npm run docs:clean && npm run docs:build && cd _book && git init && git commit --allow-empty -m 'update book' && git checkout -b gh-pages && touch .nojekyll && git add . && git commit -am 'update book' && git push git@github.com:Travix-International/frint gh-pages --force"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Travix-International/frint.git"
-  },
   "author": {
     "name": "Travix International",
     "url": "http://travix.com"
+  },
+  "bugs": {
+    "url": "https://github.com/Travix-International/frint/issues"
   },
   "contributors": [
     {
@@ -46,11 +24,6 @@
       "url": "https://github.com/alexmiranda"
     }
   ],
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/Travix-International/frint/issues"
-  },
-  "homepage": "https://github.com/Travix-International/frint#readme",
   "dependencies": {
     "lodash": "^4.13.1",
     "react": "^0.14.8",
@@ -59,6 +32,7 @@
     "redux-logger": "^2.6.1",
     "rxjs": "^5.0.0-rc.1"
   },
+  "description": "Framework for building front-end apps",
   "devDependencies": {
     "alex": "^4.0.1",
     "babel-cli": "^6.10.1",
@@ -81,5 +55,34 @@
     "rimraf": "^2.5.2",
     "sinon": "^1.17.4",
     "sinon-chai": "^2.8.0"
-  }
+  },
+  "greenkeeper": {
+    "ignore": ["react", "react-dom"]
+  },
+  "homepage": "https://github.com/Travix-International/frint#readme",
+  "license": "MIT",
+  "main": "./lib/index.js",
+  "name": "frint",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Travix-International/frint.git"
+  },
+  "scripts": {
+    "alex": "npm run alex:docs && npm run alex:code",
+    "alex:code": "for file in $(find . -path ./node_modules -prune -o -name '*.js' -print); do echo \"\nchecking $file:\" && cat $file | ./node_modules/.bin/alex; done",
+    "alex:docs": "alex",
+    "build": "webpack",
+    "cover": "nyc --reporter=lcov --require babel-register mocha && npm run cover:report",
+    "cover:report": "nyc report",
+    "coverage:coveralls": "cat ./coverage/lcov.info | coveralls",
+    "docs:build": "npm run docs:prepare && gitbook build -g Travix-International/frint",
+    "docs:clean": "rimraf _book",
+    "docs:prepare": "gitbook install",
+    "docs:publish": "npm run docs:clean && npm run docs:build && cd _book && git init && git commit --allow-empty -m 'update book' && git checkout -b gh-pages && touch .nojekyll && git add . && git commit -am 'update book' && git push git@github.com:Travix-International/frint gh-pages --force",
+    "docs:watch": "npm run docs:prepare && gitbook serve",
+    "lint": "eslint --color '{src,test}/**/*.js'",
+    "test": "npm run cover",
+    "transpile": "babel src --out-dir lib"
+  },
+  "version": "0.9.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,32 @@
 {
+  "name": "frint",
+  "version": "0.9.0",
+  "description": "Framework for building front-end apps",
+  "main": "./lib/index.js",
+  "scripts": {
+    "build": "webpack",
+    "transpile": "babel src --out-dir lib",
+    "lint": "eslint --color '{src,test}/**/*.js'",
+    "cover": "nyc --reporter=lcov --require babel-register mocha && npm run cover:report",
+    "cover:report": "nyc report",
+    "test": "npm run cover",
+    "coverage:coveralls": "cat ./coverage/lcov.info | coveralls",
+    "alex:docs": "alex",
+    "alex:code": "for file in $(find . -path ./node_modules -prune -o -name '*.js' -print); do echo \"\nchecking $file:\" && cat $file | ./node_modules/.bin/alex; done",
+    "alex": "npm run alex:docs && npm run alex:code",
+    "docs:prepare": "gitbook install",
+    "docs:clean": "rimraf _book",
+    "docs:build": "npm run docs:prepare && gitbook build -g Travix-International/frint",
+    "docs:watch": "npm run docs:prepare && gitbook serve",
+    "docs:publish": "npm run docs:clean && npm run docs:build && cd _book && git init && git commit --allow-empty -m 'update book' && git checkout -b gh-pages && touch .nojekyll && git add . && git commit -am 'update book' && git push git@github.com:Travix-International/frint gh-pages --force"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Travix-International/frint.git"
+  },
   "author": {
     "name": "Travix International",
     "url": "http://travix.com"
-  },
-  "bugs": {
-    "url": "https://github.com/Travix-International/frint/issues"
   },
   "contributors": [
     {
@@ -24,6 +46,11 @@
       "url": "https://github.com/alexmiranda"
     }
   ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Travix-International/frint/issues"
+  },
+  "homepage": "https://github.com/Travix-International/frint#readme",
   "dependencies": {
     "lodash": "^4.13.1",
     "react": "^0.14.8",
@@ -32,7 +59,6 @@
     "redux-logger": "^2.6.1",
     "rxjs": "^5.0.0-rc.1"
   },
-  "description": "Framework for building front-end apps",
   "devDependencies": {
     "alex": "^4.0.1",
     "babel-cli": "^6.10.1",
@@ -58,31 +84,5 @@
   },
   "greenkeeper": {
     "ignore": ["react", "react-dom"]
-  },
-  "homepage": "https://github.com/Travix-International/frint#readme",
-  "license": "MIT",
-  "main": "./lib/index.js",
-  "name": "frint",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Travix-International/frint.git"
-  },
-  "scripts": {
-    "alex": "npm run alex:docs && npm run alex:code",
-    "alex:code": "for file in $(find . -path ./node_modules -prune -o -name '*.js' -print); do echo \"\nchecking $file:\" && cat $file | ./node_modules/.bin/alex; done",
-    "alex:docs": "alex",
-    "build": "webpack",
-    "cover": "nyc --reporter=lcov --require babel-register mocha && npm run cover:report",
-    "cover:report": "nyc report",
-    "coverage:coveralls": "cat ./coverage/lcov.info | coveralls",
-    "docs:build": "npm run docs:prepare && gitbook build -g Travix-International/frint",
-    "docs:clean": "rimraf _book",
-    "docs:prepare": "gitbook install",
-    "docs:publish": "npm run docs:clean && npm run docs:build && cd _book && git init && git commit --allow-empty -m 'update book' && git checkout -b gh-pages && touch .nojekyll && git add . && git commit -am 'update book' && git push git@github.com:Travix-International/frint gh-pages --force",
-    "docs:watch": "npm run docs:prepare && gitbook serve",
-    "lint": "eslint --color '{src,test}/**/*.js'",
-    "test": "npm run cover",
-    "transpile": "babel src --out-dir lib"
-  },
-  "version": "0.9.0"
+  }
 }


### PR DESCRIPTION
# What does this PR do:
* Adds common patterns for 'macOS', 'OSX', 'VisualStudioCode', 'SublimeText' and 'WebStorm' to the `.gitignore`.
* Adds a section _greenkeeper_ to the `package.json` in order to specify packages to ignore (we don't want to upgrade `react` and `react-dom` for now)

# Where should the reviewer start:
  - Diffs

# Unit and/or functional tests:
N/A