### PR TITLE
Uses alexjs's ability to receive globs in order to parse other extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "npm run cover",
     "coverage:coveralls": "cat ./coverage/lcov.info | coveralls",
     "alex:docs": "alex",
-    "alex:code": "for file in $(find . -path ./node_modules -prune -o -name '*.js' -print); do echo \"\nchecking $file:\" && cat $file | ./node_modules/.bin/alex; done",
+    "alex:code": "./node_modules/.bin/alex src/**/*.js",
     "alex": "npm run alex:docs && npm run alex:code",
     "docs:prepare": "gitbook install",
     "docs:clean": "rimraf _book",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "npm run cover",
     "coverage:coveralls": "cat ./coverage/lcov.info | coveralls",
     "alex:docs": "alex",
-    "alex:code": "./node_modules/.bin/alex src/**/*.js",
+    "alex:code": "alex src/**/*.js",
     "alex": "npm run alex:docs && npm run alex:code",
     "docs:prepare": "gitbook install",
     "docs:clean": "rimraf _book",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "npm run cover",
     "coverage:coveralls": "cat ./coverage/lcov.info | coveralls",
     "alex:docs": "alex",
-    "alex:code": "alex src/**/*.js",
+    "alex:code": "alex 'src/**/*.js'",
     "alex": "npm run alex:docs && npm run alex:code",
     "docs:prepare": "gitbook install",
     "docs:clean": "rimraf _book",


### PR DESCRIPTION
# What does this PR do:
* Changes `alex:code` script on `package.json` to pass a specific glob to `alex` instead of doing a `find`. `alex` already ignores `node_modules` so no need to ignore them either.

# Where should the reviewer start:
  - Diffs

# Unit and/or functional tests:
N/A