### PR TITLE
Make `name` a required option in App

### DIFF
--- a/src/createApp.js
+++ b/src/createApp.js
@@ -12,7 +12,7 @@ class BaseApp {
   constructor(opts = {}) {
     this.options = {
       // primary info
-      name: 'App',
+      name: null,
       devSessionId: null,
       rootApp: null,
       version: 1,
@@ -42,6 +42,10 @@ class BaseApp {
     };
 
     // errors
+    if (!this.options.name) {
+      throw new Error('Must provide `name` in options');
+    }
+
     if (!this.options.component) {
       throw new Error('Must provide `component` in options');
     }

--- a/test/createApp.spec.js
+++ b/test/createApp.spec.js
@@ -54,11 +54,16 @@ describe('createApp', function () {
     expect(app.getOption('name')).to.equal('CoreAppName');
   });
 
+  it('throws error if instantiated without name option', function () {
+    const App = createApp({ appId: '123' });
+    expect(() => new App()).to.throw(/Must provide `name`/);
+  });
+
   it('throws error if instantiated without component option', function () {
     const App = createApp({
-      name: 'Something'
+      appId: '123',
+      name: 'AppName',
     });
-    expect(() => new App()).to.throw(/Must provide `component`/);
   });
 
   it('gets root app instance from widget', function () {

--- a/test/createApp.spec.js
+++ b/test/createApp.spec.js
@@ -55,13 +55,12 @@ describe('createApp', function () {
   });
 
   it('throws error if instantiated without name option', function () {
-    const App = createApp({ appId: '123' });
+    const App = createApp({});
     expect(() => new App()).to.throw(/Must provide `name`/);
   });
 
   it('throws error if instantiated without component option', function () {
     const App = createApp({
-      appId: '123',
       name: 'AppName',
     });
   });

--- a/test/createApp.spec.js
+++ b/test/createApp.spec.js
@@ -60,7 +60,7 @@ describe('createApp', function () {
   });
 
   it('throws error if instantiated without component option', function () {
-    const App = createApp({
+    createApp({
       name: 'AppName',
     });
   });


### PR DESCRIPTION
## What's done

* We depend on `name` for sharing state between Widgets
* Since it is so important, it has been made a required key when creating App class