### PR TITLE
Generate dist when publishing to npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ fabric.properties
 
 examples/**/build/js/*.js
 examples/**/build/js/*.map
+
+dist/frint.js
+dist/frint.min.js

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ release:
 	git checkout master
 	git pull origin master
 	npm run transpile
+	npm run dist
 	npm version $(VERSION)
 	npm publish
 	git push --follow-tags

--- a/dist/webpack.config.js
+++ b/dist/webpack.config.js
@@ -1,0 +1,29 @@
+module.exports = {
+  entry: __dirname + '/../src',
+  output: {
+    path: __dirname,
+    filename: 'frint.js',
+    libraryTarget: 'this',
+    library: 'Frint'
+  },
+  externals: {
+    'lodash': '_',
+    'react': 'React',
+    'react-dom': 'ReactDOM',
+    'rxjs': 'Rx',
+  },
+  module: {
+    loaders: [
+      {
+        test: /\.js$/,
+        exclude: /(node_modules)/,
+        loader: 'babel-loader',
+        query: {
+          presets: [
+            'travix'
+          ]
+        }
+      }
+    ]
+  }
+};

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "alex:docs": "alex",
     "alex:code": "alex 'src/**/*.js'",
     "alex": "npm run alex:docs && npm run alex:code",
+    "dist:lib": "webpack --config ./dist/webpack.config.js",
+    "dist:min": "uglifyjs dist/frint.js --output dist/frint.min.js",
+    "dist": "npm run dist:lib && npm run dist:min",
     "docs:prepare": "gitbook install",
     "docs:clean": "rimraf _book",
     "docs:build": "npm run docs:prepare && gitbook build -g Travix-International/frint",
@@ -83,6 +86,7 @@
     "rimraf": "^2.5.2",
     "sinon": "^1.17.4",
     "sinon-chai": "^2.8.0",
+    "uglify-js": "^2.7.5",
     "webpack": "^1.14.0"
   },
   "greenkeeper": {


### PR DESCRIPTION
## What's done

When `frint` is published to `npm` next time, it would generate and upload the dist files too, and that would make it available via CDN:

Example URL: https://unpkg.com/frint@0.10.1/dist/frint.min.js

## Usage example

```html
<!-- dependencies -->
<script src="https://cdnjs.cloudflare.com/ajax/libs/react/0.14.8/react.min.js"></script>
<script src="https://cdnjs.cloudflare.com/ajax/libs/react/0.14.8/react-dom.min.js"></script>
<script src="https://cdnjs.cloudflare.com/ajax/libs/rxjs/5.0.0-rc.5/Rx.min.js"></script>
<script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.2/lodash.min.js"></script>

<!-- frint -->
<script src="https://unpkg.com/frint@0.10.1/dist/frint.min.js"></script>

<script>
  // frint is now available as `window.Frint`
</script>
```