### PR TITLE
Check if `window` exists before setting Root app

### DIFF
--- a/src/createApp.js
+++ b/src/createApp.js
@@ -53,7 +53,10 @@ class BaseApp {
     // widgets
     this.widgetsByRegion = {};
 
-    if (typeof window.app !== 'undefined') {
+    if (
+      typeof window !== 'undefined' &&
+      typeof window.app !== 'undefined'
+    ) {
       this.options.rootApp = window.app;
     }
 


### PR DESCRIPTION
This check is needed to use `frint` in server-side, without involving any `jsdom` magic in globals.