### PR TITLE
Check if `window` exists in Region

### DIFF
--- a/src/components/Region.js
+++ b/src/components/Region.js
@@ -13,7 +13,10 @@ function getObservable$(name) {
 }
 
 function isRootAppAvailable() {
-  return window.app;
+  return (
+    typeof window !== 'undefined' &&
+    window.app
+  );
 }
 
 export default React.createClass({


### PR DESCRIPTION
This is again needed for server side rendering, in non-testing environments.