### PR TITLE
Hyperscript for JSX

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,10 @@
 {
   "presets": [
     "travix"
+  ],
+  "plugins": [
+    ["transform-react-jsx", {
+      "pragma": "h"
+    }]
   ]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -2,5 +2,10 @@
   "extends": [
     "travix"
   ],
-  "parser": "babel-eslint"
+  "parser": "babel-eslint",
+  "settings": {
+    "react": {
+      "pragma": "h"
+    }
+  }
 }

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -27,6 +27,7 @@
 * [API Reference](/docs/api/README.md)
   * [createApp](/docs/api/createApp.md)
   * [createComponent](/docs/api/createComponent.md)
+  * [h](/docs/api/h.md)
   * [PropTypes](/docs/api/PropTypes.md)
   * [combineReducers](/docs/api/combineReducers.md)
   * [createModel](/docs/api/createModel.md)

--- a/docs/api/Component.md
+++ b/docs/api/Component.md
@@ -5,7 +5,8 @@ Component classes ready to be embedded as JSX for rendering.
 ## Usage
 
 ```js
-import { createComponent } from 'frint';
+/** @jsx h */
+import { createComponent, h } from 'frint';
 
 const MyComponent = createComponent({
   render() {

--- a/docs/api/Region.md
+++ b/docs/api/Region.md
@@ -7,7 +7,8 @@ When you embed this Component with a given `name`, any time other apps register 
 ## Example
 
 ```js
-import { createComponent, Region } from 'frint';
+/** @jsx h */
+import { createComponent, Region, h } from 'frint';
 
 const MyComponent = createComponent({
   render() {

--- a/docs/api/createComponent.md
+++ b/docs/api/createComponent.md
@@ -5,7 +5,8 @@ Creates Component classes with a `render` method, for returning JSX.
 ## Usage
 
 ```js
-import { createComponent } from 'frint';
+/** @jsx h */
+import { createComponent, h } from 'frint';
 
 const MyComponent = createComponent({
   render() {
@@ -20,7 +21,8 @@ The `createComponent` function also adds some custom methods to the object passe
 by the instance of the component.
 
 ```js
-import { createComponent } from 'frint';
+/** @jsx h */
+import { createComponent, h } from 'frint';
 
 const MyComponent = createComponent({
   handleSubmit(e) {
@@ -47,6 +49,7 @@ it will return `null`.
 On the object passed to `createComponent`, certain lifecycle events can be defined. These will be called by the framework automatically.
 
 ```js
+/** @jsx h */
 const MyComponent = createComponent({
   afterMount() {
     console.log('my component: afterMount');

--- a/docs/api/h.md
+++ b/docs/api/h.md
@@ -1,0 +1,52 @@
+# h
+
+Hyperscript for JSX.
+
+## Usage
+
+The `h` function just needs to exist in the same scope, wherever you are using JSX.
+
+You can manually tell your transpiler (Babel in this example), which function to use at file-level:
+
+```js
+/** @jsx h */
+import { createComponent, h } from 'frint';
+
+const MyComponent = createComponent({
+  render() {
+    return (
+      <p>Name is {this.prop.name}</p>
+    );
+  }
+});
+```
+
+Or you can also set it up in your `.babelrc` file globally:
+
+```
+// .babelrc
+{
+  "presets": [
+    "travix"
+  ],
+  "plugins": [
+    ["transform-react-jsx", {
+      "pragma": "h"
+    }]
+  ]
+}
+```
+
+In that case, you wouldn't need the extra `/** @jsx h */` comment block:
+
+```js
+import { createComponent, h } from 'frint';
+
+const MyComponent = createComponent({
+  render() {
+    return (
+      <p>Name is {this.prop.name}</p>
+    );
+  }
+});
+```

--- a/docs/api/mapToProps.md
+++ b/docs/api/mapToProps.md
@@ -7,7 +7,8 @@ This is a handy function that is used for enhancing your Components, by injectin
 If you want to get values from state, and bind the values as they change to your Component as props, you can:
 
 ```js
-import { createComponent, mapToProps } from 'frint';
+/** @jsx h */
+import { createComponent, mapToProps, h } from 'frint';
 
 const MyComponent = createComponent({
   render() {
@@ -27,7 +28,8 @@ export default mapToProps({
 ## Actions
 
 ```js
-import { createComponent, mapToProps } from 'frint';
+/** @jsx h */
+import { createComponent, mapToProps, h } from 'frint';
 
 import { addTodo } from '../actions/todos';
 

--- a/docs/guides/create-app/Component.md
+++ b/docs/guides/create-app/Component.md
@@ -4,8 +4,8 @@ Previously, we saw that App requires a Component for rendering. We will write ou
 
 ```js
 // components/Root.js
-
-import { createComponent } from 'frint';
+/** @jsx h */
+import { createComponent, h } from 'frint';
 
 export default createComponent({
   render() {
@@ -15,3 +15,5 @@ export default createComponent({
   }
 });
 ```
+
+If you have already configured your transpiler to point JSX pragma to frint's `h` function, then you don't need the comment block `/** @jsx h */`.

--- a/docs/guides/create-app/Transpiler.md
+++ b/docs/guides/create-app/Transpiler.md
@@ -9,3 +9,22 @@ We use Babel for transpiling ES6/JSX code to browser compatible ES5. Since we al
   ]
 }
 ```
+
+## JSX
+
+If you want to avoid pointing to frint's JSX pragma function in every file that involves JSX, you can do:
+
+```json
+{
+  "presets": [
+    "travix"
+  ],
+  "plugins": [
+    ["transform-react-jsx", {
+      "pragma": "h"
+    }]
+  ]
+}
+```
+
+More discussed in [Component](./Component.md) page.

--- a/docs/guides/create-app/Transpiler.md
+++ b/docs/guides/create-app/Transpiler.md
@@ -28,3 +28,21 @@ If you want to avoid pointing to frint's JSX pragma function in every file that 
 ```
 
 More discussed in [Component](./Component.md) page.
+
+### ESLint
+
+ESLint configuration can be used as follows:
+
+```json
+{
+  "extends": [
+    "travix"
+  ],
+  "parser": "babel-eslint",
+  "settings": {
+    "react": {
+      "pragma": "h"
+    }
+  }
+}
+```

--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -1,0 +1,3 @@
+import { combineReducers } from 'redux';
+
+export default combineReducers;

--- a/src/components/Region.js
+++ b/src/components/Region.js
@@ -3,6 +3,8 @@
 import _ from 'lodash';
 import React, { PropTypes } from 'react';
 
+import h from '../h';
+
 // @TODO: check for an alternative to remove global dependency
 function getWidgets(name) {
   return window.app.getWidgets(name);

--- a/src/components/mapToProps.js
+++ b/src/components/mapToProps.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import React, { PropTypes } from 'react';
 import { Observable } from 'rxjs';
 
+import h from '../h';
 import isObservable from '../utils/isObservable';
 
 export default function mapToProps(opts = {}) {

--- a/src/createApp.js
+++ b/src/createApp.js
@@ -1,12 +1,13 @@
 /* eslint-disable no-console, no-underscore-dangle */
 /* globals window */
 import { Subject } from 'rxjs';
-import React from 'react';
 import { createStore, applyMiddleware, compose } from 'redux';
 import _ from 'lodash';
+
 import createAppendActionMiddleware from './middlewares/appendAction';
 import createAsyncMiddleware from './middlewares/async';
 import Provider from './components/Provider';
+import h from './h';
 
 class BaseApp {
   constructor(opts = {}) {

--- a/src/h.js
+++ b/src/h.js
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export default React.createElement;

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
-import { combineReducers } from 'redux';
-
+import combineReducers from './combineReducers';
 import createApp from './createApp';
 import createComponent from './createComponent';
 import createFactory from './createFactory';
@@ -11,6 +10,7 @@ import PropTypes from './PropTypes';
 import Region from './components/Region';
 import render from './render';
 import isObservable from './utils/isObservable';
+import h from './h';
 
 export default {
   combineReducers,
@@ -25,4 +25,5 @@ export default {
   Region,
   render,
   isObservable,
+  h,
 };

--- a/src/render.js
+++ b/src/render.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import h from './h';
+
 export default function render(app, node) {
   const Component = app.render();
 

--- a/src/server/renderToString.js
+++ b/src/server/renderToString.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   renderToString as reactRenderToString
 } from 'react-dom/server';

--- a/src/server/renderToString.js
+++ b/src/server/renderToString.js
@@ -3,6 +3,8 @@ import {
   renderToString as reactRenderToString
 } from 'react-dom/server';
 
+import { h } from '../';
+
 export default function renderToString(app) {
   const Component = app.render();
 

--- a/test/Model.spec.js
+++ b/test/Model.spec.js
@@ -1,6 +1,7 @@
 /* global describe, it */
 import { expect } from 'chai';
-import Model from '../src/Model';
+
+import { Model } from '../src';
 
 describe('Model', () => {
   const myAttributes = {

--- a/test/PropTypes.spec.js
+++ b/test/PropTypes.spec.js
@@ -1,6 +1,6 @@
 /* global describe, it */
 import { expect } from 'chai';
-import PropTypes from '../src/PropTypes';
+import { PropTypes } from '../src';
 
 describe('PropTypes', () => {
   it('checks for existence of various types', () => {

--- a/test/components/Provider.spec.js
+++ b/test/components/Provider.spec.js
@@ -5,6 +5,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 
 import Provider from '../../src/components/Provider';
+import { h } from '../../src';
 
 const sandbox = sinon.sandbox.create();
 chai.use(sinonChai);

--- a/test/components/Provider.spec.js
+++ b/test/components/Provider.spec.js
@@ -3,6 +3,7 @@ import chai, { expect } from 'chai';
 import React, { Children, Component, PropTypes } from 'react';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
+
 import Provider from '../../src/components/Provider';
 
 const sandbox = sinon.sandbox.create();

--- a/test/components/Provider.spec.js
+++ b/test/components/Provider.spec.js
@@ -1,6 +1,6 @@
 /* global afterEach, beforeEach, describe, it */
 import chai, { expect } from 'chai';
-import React, { Children, Component, PropTypes } from 'react';
+import { Children, Component, PropTypes } from 'react';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 

--- a/test/components/Region.spec.js
+++ b/test/components/Region.spec.js
@@ -11,7 +11,8 @@ import {
   combineReducers,
   render,
   Region,
-  mapToProps
+  mapToProps,
+  h
 } from '../../src';
 
 describe('components › Region', () => {

--- a/test/components/mapToProps.spec.js
+++ b/test/components/mapToProps.spec.js
@@ -1,6 +1,5 @@
 /* global afterEach, beforeEach, describe, it, window, document, before, resetDOM */
 import { expect } from 'chai';
-import React from 'react';
 import { Observable } from 'rxjs';
 
 import {
@@ -12,7 +11,8 @@ import {
   createFactory,
   createModel,
   Region,
-  mapToProps
+  mapToProps,
+  h,
 } from '../../src';
 
 describe('components › mapToProps', function () {

--- a/test/createComponent.spec.js
+++ b/test/createComponent.spec.js
@@ -5,7 +5,10 @@ import ReactDOM from 'react-dom';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 
-import { createComponent } from '../src';
+import {
+  createComponent,
+  h,
+} from '../src';
 
 const sandbox = sinon.sandbox.create();
 chai.use(sinonChai);

--- a/test/createComponent.spec.js
+++ b/test/createComponent.spec.js
@@ -4,7 +4,8 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import createComponent from '../src/createComponent';
+
+import { createComponent } from '../src';
 
 const sandbox = sinon.sandbox.create();
 chai.use(sinonChai);
@@ -21,7 +22,7 @@ describe('createComponent', () => {
   beforeEach(() => {
     sandbox.spy(React, 'createClass');
     MyComponent = createComponent(mySpec);
-    myComponentInstance = ReactDOM.render(React.createElement(MyComponent), document.getElementById('root'));
+    myComponentInstance = ReactDOM.render(<MyComponent />, document.getElementById('root'));
   });
 
   afterEach(() => {

--- a/test/createFactory.spec.js
+++ b/test/createFactory.spec.js
@@ -2,7 +2,8 @@
 import chai, { expect } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import createFactory from '../src/createFactory';
+
+import { createFactory } from '../src';
 
 chai.use(sinonChai);
 

--- a/test/createModel.spec.js
+++ b/test/createModel.spec.js
@@ -1,7 +1,10 @@
 /* global describe, it */
 import { expect } from 'chai';
-import BaseModel from '../src/Model';
-import createModel from '../src/createModel';
+
+import {
+  Model as BaseModel,
+  createModel,
+} from '../src';
 
 describe('createModel', () => {
   const mySpec = {

--- a/test/createService.spec.js
+++ b/test/createService.spec.js
@@ -2,7 +2,8 @@
 import chai, { expect } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import createService from '../src/createService';
+
+import { createService } from '../src';
 
 chai.use(sinonChai);
 

--- a/test/render.spec.js
+++ b/test/render.spec.js
@@ -4,7 +4,8 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import render from '../src/render';
+
+import { render } from '../src';
 
 chai.use(sinonChai);
 

--- a/test/server/renderToString.spec.js
+++ b/test/server/renderToString.spec.js
@@ -4,7 +4,8 @@ import React from 'react';
 
 import {
   createApp,
-  createComponent
+  createComponent,
+  h,
 } from '../../src';
 import renderToString from '../../src/server/renderToString';
 

--- a/test/server/renderToString.spec.js
+++ b/test/server/renderToString.spec.js
@@ -1,6 +1,5 @@
 /* global describe, it */
 import { expect } from 'chai';
-import React from 'react';
 
 import {
   createApp,


### PR DESCRIPTION
## Problem

We are still dependent on JSX being transpiled into code like `React.createElement(...)`, which makes it a requirement for us to expose `React` globally.

In the browser we are not facing any issues, because React is available globally already as `window.React`.

But in the server-side, it's a problem unless you set `global.React = require('react')`.

## Solution

Instead of depending on React globally, we are now exposing an `h` function, which we can import wherever we use JSX.

And it comes from `frint`.

`h` is the replacement of direct usage of `React.createElement`.

## Examples

### Component

The `h` function needs to exist in the scope, wherever we use JSX.

```js
import { createComponent, h } from 'frint';

export default createComponent({
  render() {
    return (
      <p>Hello World</p>
    );
  }
});
```

And it gets transpiled to:

```js
import { createComponent, h } from 'frint';

export default createComponent({
  render() {
    return h(
      'p',
      null,
      'Hello World'
    );
  }
});
```

### Babel

File-level, with comment:

```js
/** @jsx h */
import { createComponent, h } from 'frint';

export default createComponent({
  render() {
    return <p>Hello World</p>
  }
});
```

If you don't want to set it in every file as a comment, you can set it globally in your `.babelrc` file:

```json
{
  "presets": [
    "travix"
  ],
  "plugins": [
    ["transform-react-jsx", {
      "pragma": "h"
    }]
  ]
}
```

### ESLint

Your `.eslintrc` file can look like:

```json
{
  "extends": [
    "travix"
  ],
  "parser": "babel-eslint",
  "settings": {
    "react": {
      "pragma": "h"
    }
  }
}
```

---

**Note**: Not a breaking change.