### PR TITLE
Examples: use CDN url for `frint`

### DIFF
--- a/examples/config.js
+++ b/examples/config.js
@@ -4,5 +4,6 @@ module.exports = {
     'react': 'React',
     'react-dom': 'ReactDOM',
     'rxjs': 'Rx',
+    'frint': 'Frint',
   }
 };

--- a/examples/counter/README.md
+++ b/examples/counter/README.md
@@ -1,5 +1,12 @@
 # Counter
 
+Example demonstrating:
+
+* A Core app
+* With a counter having increment/decrement buttons
+
+## Usage
+
 Run:
 
 ```

--- a/examples/counter/build/index.html
+++ b/examples/counter/build/index.html
@@ -11,8 +11,10 @@
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/react/0.14.8/react.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/react/0.14.8/react-dom.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/rxjs/5.0.0-rc.5/Rx.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.2/lodash.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/rxjs/5.0.2/Rx.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.3/lodash.min.js"></script>
+
+    <script src="https://unpkg.com/frint@0.x/dist/frint.min.js"></script>
 
     <script src="./js/core.js"></script>
   </body>

--- a/examples/counter/core/app/index.js
+++ b/examples/counter/core/app/index.js
@@ -1,4 +1,4 @@
-import { createApp } from '../../../../src';
+import { createApp } from 'frint';
 
 import RootComponent from '../components/Root';
 import rootReducer from '../reducers';

--- a/examples/counter/core/components/Root.js
+++ b/examples/counter/core/components/Root.js
@@ -1,4 +1,4 @@
-import { createComponent, mapToProps } from '../../../../src';
+import { createComponent, mapToProps } from 'frint';
 
 import {
   incrementCounter,

--- a/examples/counter/core/index.js
+++ b/examples/counter/core/index.js
@@ -1,4 +1,4 @@
-import { render } from '../../../src';
+import { render } from 'frint';
 
 import App from './app';
 

--- a/examples/counter/core/reducers/index.js
+++ b/examples/counter/core/reducers/index.js
@@ -1,4 +1,4 @@
-import { combineReducers } from '../../../../src';
+import { combineReducers } from 'frint';
 
 import counter from './counter';
 

--- a/examples/multiple-widgets/README.md
+++ b/examples/multiple-widgets/README.md
@@ -1,5 +1,13 @@
 # Multiple widgets
 
+Example demonstating:
+
+* A Core app
+* Loading multiple Widgets
+* Widgets sharing each other's state
+
+## Usage
+
 Run:
 
 ```

--- a/examples/multiple-widgets/build/index.html
+++ b/examples/multiple-widgets/build/index.html
@@ -11,8 +11,10 @@
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/react/0.14.8/react.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/react/0.14.8/react-dom.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/rxjs/5.0.0-rc.5/Rx.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.2/lodash.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/rxjs/5.0.2/Rx.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.3/lodash.min.js"></script>
+
+    <script src="https://unpkg.com/frint@0.x/dist/frint.min.js"></script>
 
     <script src="./js/core.js"></script>
     <script src="./js/widget-foo.js"></script>

--- a/examples/multiple-widgets/core/app/index.js
+++ b/examples/multiple-widgets/core/app/index.js
@@ -1,4 +1,4 @@
-import { createApp } from '../../../../src';
+import { createApp } from 'frint';
 
 import RootComponent from '../components/Root';
 

--- a/examples/multiple-widgets/core/components/Root.js
+++ b/examples/multiple-widgets/core/components/Root.js
@@ -1,4 +1,4 @@
-import { createComponent, Region } from '../../../../src';
+import { createComponent, Region } from 'frint';
 
 export default createComponent({
   render() {

--- a/examples/multiple-widgets/core/index.js
+++ b/examples/multiple-widgets/core/index.js
@@ -1,4 +1,4 @@
-import { render } from '../../../src';
+import { render } from 'frint';
 
 import App from './app';
 

--- a/examples/multiple-widgets/widget-bar/app/index.js
+++ b/examples/multiple-widgets/widget-bar/app/index.js
@@ -1,4 +1,4 @@
-import { createApp } from '../../../../src';
+import { createApp } from 'frint';
 
 import RootComponent from '../components/Root';
 import rootReducer from '../reducers';

--- a/examples/multiple-widgets/widget-bar/components/Root.js
+++ b/examples/multiple-widgets/widget-bar/components/Root.js
@@ -1,4 +1,4 @@
-import { createComponent, mapToProps } from '../../../../src';
+import { createComponent, mapToProps } from 'frint';
 
 import {
   changeColor

--- a/examples/multiple-widgets/widget-bar/reducers/index.js
+++ b/examples/multiple-widgets/widget-bar/reducers/index.js
@@ -1,4 +1,4 @@
-import { combineReducers } from '../../../../src';
+import { combineReducers } from 'frint';
 
 import color from './color';
 

--- a/examples/multiple-widgets/widget-foo/app/index.js
+++ b/examples/multiple-widgets/widget-foo/app/index.js
@@ -1,4 +1,4 @@
-import { createApp } from '../../../../src';
+import { createApp } from 'frint';
 
 import RootComponent from '../components/Root';
 import rootReducer from '../reducers';

--- a/examples/multiple-widgets/widget-foo/components/Root.js
+++ b/examples/multiple-widgets/widget-foo/components/Root.js
@@ -1,4 +1,4 @@
-import { createComponent, mapToProps } from '../../../../src';
+import { createComponent, mapToProps } from 'frint';
 
 import {
   incrementCounter,

--- a/examples/multiple-widgets/widget-foo/reducers/index.js
+++ b/examples/multiple-widgets/widget-foo/reducers/index.js
@@ -1,4 +1,4 @@
-import { combineReducers } from '../../../../src';
+import { combineReducers } from 'frint';
 
 import counter from './counter';
 


### PR DESCRIPTION
## What's done

In the examples, use CDN url for loading `frint` in the browser, resulting in smaller bundle sizes for Core apps and Widgets (`<= 8kB unminified` each).

The CDN url is: https://unpkg.com/frint@0.x/dist/frint.min.js

**Hint**: Look into `index.html` files in the diff.