### PR TITLE
Logger middleware

### DIFF
--- a/examples/counter/Makefile
+++ b/examples/counter/Makefile
@@ -1,3 +1,6 @@
-serve:
+bundle:
 	(cd ./core && npm run build)
+
+serve:
+	make bundle
 	(cd ./build && ../../../node_modules/.bin/http-server -p 5001)

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "react": "^0.14.8",
     "react-dom": "^0.14.8",
     "redux": "^3.5.2",
-    "redux-logger": "^2.6.1",
     "rxjs": "^5.0.1"
   },
   "devDependencies": {

--- a/src/createApp.js
+++ b/src/createApp.js
@@ -141,7 +141,7 @@ class BaseApp {
 
     if (process.env.NODE_ENV !== 'production') {
       if (this.getOption('enableLogger') === true) {
-        const createLogger = require('redux-logger'); // eslint-disable-line
+        const createLogger = require('./middlewares/logger'); // eslint-disable-line
 
         middlewares.push(createLogger());
       }

--- a/src/middlewares/logger.js
+++ b/src/middlewares/logger.js
@@ -2,6 +2,7 @@
 export default function (options = {}) {
   const opts = {
     throwError: true,
+    console: console,
     ...options,
   };
 
@@ -26,16 +27,16 @@ export default function (options = {}) {
     const d = new Date();
     const groupName = `action @ ${d.getHours()}:${d.getMinutes()}:${d.getSeconds()}.${d.getMilliseconds()} ${action.type}`;
 
-    if (typeof console.group === 'function') {
-      console.group(groupName);
+    if (typeof opts.console.group === 'function') {
+      opts.console.group(groupName);
     }
 
-    console.log('%cprevious state', 'color: #9e9e9e; font-weight: bold;', prevState);
-    console.log('%caction', 'color: #33c3f0; font-weight: bold;', action);
-    console.log('%ccurrent state', 'color: #4cAf50; font-weight: bold;', store.getState());
+    opts.console.log('%cprevious state', 'color: #9e9e9e; font-weight: bold;', prevState);
+    opts.console.log('%caction', 'color: #33c3f0; font-weight: bold;', action);
+    opts.console.log('%ccurrent state', 'color: #4cAf50; font-weight: bold;', store.getState());
 
-    if (typeof console.group === 'function') {
-      console.groupEnd();
+    if (typeof opts.console.group === 'function') {
+      opts.console.groupEnd();
     }
 
     return nextAction;

--- a/src/middlewares/logger.js
+++ b/src/middlewares/logger.js
@@ -1,0 +1,43 @@
+/* eslint-disable no-console */
+export default function (options = {}) {
+  const opts = {
+    throwError: true,
+    ...options,
+  };
+
+  return store => next => action => { // eslint-disable-line
+    let nextAction;
+    let error;
+
+    const prevState = store.getState();
+
+    try {
+      nextAction = next({
+        ...action,
+      });
+    } catch (e) {
+      error = e;
+    }
+
+    if (opts.throwError && error) {
+      throw error;
+    }
+
+    const d = new Date();
+    const groupName = `action @ ${d.getHours()}:${d.getMinutes()}:${d.getSeconds()}.${d.getMilliseconds()} ${action.type}`;
+
+    if (typeof console.group === 'function') {
+      console.group(groupName);
+    }
+
+    console.log('%cprevious state', 'color: #9e9e9e; font-weight: bold;', prevState);
+    console.log('%caction', 'color: #33c3f0; font-weight: bold;', action);
+    console.log('%ccurrent state', 'color: #4cAf50; font-weight: bold;', store.getState());
+
+    if (typeof console.group === 'function') {
+      console.groupEnd();
+    }
+
+    return nextAction;
+  };
+}

--- a/test/middlewares/logger.spec.js
+++ b/test/middlewares/logger.spec.js
@@ -1,0 +1,126 @@
+/* global describe, it */
+import { expect } from 'chai';
+
+import createLoggerMiddleware from '../../src/middlewares/logger';
+
+describe('middlewares › logger', function () {
+  it('returns a function', function () {
+    expect(createLoggerMiddleware()).to.be.a('function');
+  });
+
+  it('logs dispatched actions', function () {
+    let consoleCallCount = 0;
+    const capturedLogs = [];
+
+    const fakeConsole = {
+      group() {
+        consoleCallCount += 1;
+      },
+      groupEnd() {
+        consoleCallCount += 1;
+      },
+      log(...args) {
+        consoleCallCount += 1;
+
+        capturedLogs.push(args.map(function (item) {
+          if (typeof item === 'string') {
+            return item;
+          }
+
+          return Object.assign({}, item);
+        }));
+      }
+    };
+
+    const fakeState = {
+      counter: {
+        value: 0
+      }
+    };
+
+    const fakeStore = {
+      dispatch(action) {
+        switch (action.type) {
+          case 'INCREMENT_COUNTER':
+            fakeState.counter.value += 1;
+            return fakeState;
+
+          case 'DECREMENT_COUNTER':
+            fakeState.counter.value -= 1;
+            return fakeState;
+
+          default:
+            return fakeState;
+        }
+      },
+
+      getState() {
+        return fakeState;
+      }
+    };
+
+    const fakeNext = function (action) {
+      fakeStore.dispatch(action);
+    };
+
+    const middleware = createLoggerMiddleware({ console: fakeConsole });
+    const action = { type: 'INCREMENT_COUNTER' };
+
+    middleware(fakeStore)(fakeNext)(action);
+    expect(consoleCallCount).to.equal(5);
+
+    // previous state
+    expect(capturedLogs[0][2], {
+      counter: {
+        value: 0
+      }
+    });
+
+    // action
+    expect(capturedLogs[1][2], {
+      type: 'INCREMENT_COUNTER'
+    });
+
+    // next state
+    expect(capturedLogs[2][2], {
+      counter: {
+        value: 1
+      }
+    });
+  });
+
+  it('throws error if action throws error', function () {
+    const fakeConsole = {
+      log() { }
+    };
+
+    const fakeState = {};
+
+    const fakeStore = {
+      dispatch(action) {
+        switch (action.type) {
+          case 'INCREMENT_COUNTER':
+            throw new Error('I am buggy');
+
+          default:
+            return fakeState;
+        }
+      },
+
+      getState() {
+        return fakeState;
+      }
+    };
+
+    const fakeNext = function (action) {
+      fakeStore.dispatch(action);
+    };
+
+    const middleware = createLoggerMiddleware({ console: fakeConsole });
+    const action = { type: 'INCREMENT_COUNTER' };
+
+    expect(function () {
+      middleware(fakeStore)(fakeNext)(action);
+    }).to.throw(/I am buggy/);
+  });
+});


### PR DESCRIPTION
## What's done

* Custom logger middleware
* `redux-logger` package removed
* With this PR, all direct dependents of `redux` has been removed
* Now leaves us with the possibility of directly using `rxjs` for Stores

**Note**: NOT a breaking change. Behaviour is still same like before.

## Preview

![screen shot 2016-12-27 at 11 49 48](https://cloud.githubusercontent.com/assets/20046/21498215/e9109a50-cc2a-11e6-9ba1-2a6ff26b112e.png)
