### PR TITLE
CNAME for frint.js.org

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+frint.js.org

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "docs:clean": "rimraf _book",
     "docs:build": "npm run docs:prepare && gitbook build -g Travix-International/frint",
     "docs:watch": "npm run docs:prepare && gitbook serve",
-    "docs:publish": "npm run docs:clean && npm run docs:build && cd _book && git init && git commit --allow-empty -m 'update book' && git checkout -b gh-pages && touch .nojekyll && git add . && git commit -am 'update book' && git push git@github.com:Travix-International/frint gh-pages --force"
+    "docs:publish": "npm run docs:clean && npm run docs:build && cp CNAME ./_book/CNAME && cd _book && git init && git commit --allow-empty -m 'update book' && git checkout -b gh-pages && touch .nojekyll && git add . && git commit -am 'update book' && git push git@github.com:Travix-International/frint gh-pages --force"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Once the `CNAME` file gets deployed to GitHub Pages, we can request for a `frint.js.org` domain name via https://dns.js.org/