### PR TITLE
Combine services and factories

### DIFF
--- a/src/_mergeServicesAndFactories.js
+++ b/src/_mergeServicesAndFactories.js
@@ -1,0 +1,12 @@
+// TODO: remove this when factories are removed
+export default function mergeServicesAndFactories(options) {
+  const { services = {}, factories = {} } = options;
+  const collidingFactoryNames = Object.keys(factories)
+    .filter(factory => factory in services && factories[factory] !== services[factory]);
+  if (collidingFactoryNames.length) {
+    throw new Error(`Colliding factory names: ${collidingFactoryNames.join(', ')}`);
+  }
+
+  Object.assign(services, factories);
+  delete options.factories;
+}

--- a/src/components/mapToProps.js
+++ b/src/components/mapToProps.js
@@ -4,8 +4,13 @@ import { Observable } from 'rxjs';
 
 import h from '../h';
 import isObservable from '../utils/isObservable';
+import mergeServicesAndFactories from '../_mergeServicesAndFactories'; // TODO: get rid of this when factories are removed
 
 export default function mapToProps(opts = {}) {
+  if ('factories' in opts) {
+    console.warn('[DEPRECATED] `factories` options has been deprecated! Use `services` instead.'); // eslint-disable-line no-console
+  }
+
   const options = {
     app: () => {},
     dispatch: {},
@@ -18,6 +23,8 @@ export default function mapToProps(opts = {}) {
     ...opts,
   };
 
+  mergeServicesAndFactories(options); // TODO: get rid of this when factories are removed
+
   return (Component) => {
     const WrappedComponent = React.createClass({
       displayName: (typeof Component.displayName !== 'undefined')
@@ -29,7 +36,6 @@ export default function mapToProps(opts = {}) {
           mappedAppToProps: {},
           readableStates: {},
           services: {},
-          factories: {},
           models: {},
         };
       },
@@ -117,9 +123,6 @@ export default function mapToProps(opts = {}) {
         this.setState({
           mappedAppToProps: options.app(this.context.app),
           services: _.mapValues(options.services, serviceName => this.context.app.getService(serviceName)),
-          factories: _.mapValues(options.factories, (factoryName) => {
-            return this.context.app.getFactory(factoryName);
-          }),
           models: _.mapValues(options.models, (modelName) => {
             return this.context.app.getModel(modelName);
           }),
@@ -142,7 +145,6 @@ export default function mapToProps(opts = {}) {
         const {
           mappedAppToProps,
           services,
-          factories,
           models,
           dispatch,
           observe,
@@ -155,7 +157,6 @@ export default function mapToProps(opts = {}) {
           ...options.shared(readableStates),
           ...mappedAppToProps,
           ...services,
-          ...factories,
           ...models,
           ...dispatch,
           ...observe,

--- a/src/createFactory.js
+++ b/src/createFactory.js
@@ -1,12 +1,7 @@
-// creation of Service and Factory classes are same as of this point
+// createFactory is an alias for createService
 import createService from './createService';
 
-export default function createFactory(extend = {}) {
-  const Service = createService(extend);
-
-  class Factory extends Service {
-
-  }
-
-  return Factory;
+export default function createFactory(...args) {
+  console.warn('[DEPRECATED] `createFactory` has been deprecated! Use `createService` instead.'); // eslint-disable-line no-console
+  return createService(...args);
 }

--- a/src/createService.js
+++ b/src/createService.js
@@ -7,8 +7,6 @@ export default function createService(extend = {}) {
         throw new Error('App instance not provided.');
       }
 
-      this.app = options.app;
-
       _.merge(this, extend);
 
       Object.keys(this)
@@ -23,3 +21,14 @@ export default function createService(extend = {}) {
 
   return Service;
 }
+
+
+export const ServiceWithDependency = createService({
+  initialize(options) {
+    this.app = options.app;
+  },
+
+  doSomething() {
+    return this.app.getService('calculator').add(2, 2);
+  }
+});

--- a/test/createFactory.spec.js
+++ b/test/createFactory.spec.js
@@ -10,7 +10,9 @@ chai.use(sinonChai);
 describe('createFactory', () => {
   const fakeAppInstance = {};
   const mySpec = {
-    initialize: sinon.stub(),
+    initialize: sinon.spy(function ({ app }) {
+      this.app = app;
+    }),
     myCustomFunction: () => 'value'
   };
 


### PR DESCRIPTION
This is related to [issue 74](https://github.com/Travix-International/frint/issues/74).

For now you can see that little unit test code has been changed.  I will later add extra unit tests that explain `singletonServices` v `appScopedServices` (aka. factories).

The only breaking change is that services or factories depending on an app instance will have to inject the `app` via `initialize` method (which used to be automatic).

The file `_mergeServicesAndFactories.js` is supposed to be temporary (thus the weird naming convention).