### PR TITLE
Undeprecate `Store.getState()`.

### DIFF
--- a/src/createStore.js
+++ b/src/createStore.js
@@ -77,8 +77,6 @@ class BaseStore {
   }
 
   getState = () => {
-    this.options.console.warn('[DEPRECATED] `Store.getState` has been deprecated, and kept for consistency purpose only with v0.x');
-
     return this.cachedState;
   }
 


### PR DESCRIPTION
Deprecation warning removed, since `getState()` is still heavily expected to be used in async actions.

Current `master` is not released yet, so the previous warning never made it into a release.