### PR TITLE
Models: `initialize` lifecycle method.

### DIFF
--- a/docs/api/createModel.md
+++ b/docs/api/createModel.md
@@ -24,3 +24,19 @@ const shirt = new MyModel({
 
 const color = shirt.getColor(); // blue
 ```
+
+### Initialization
+
+In case you want to perform some operations when initializing the model,
+you can use the lifecycle method `initialize()`.
+
+```js
+// ./models/MyModelName.js
+import { createModel } from 'frint';
+
+export default createModel({
+  initialize(attributes = {}) {
+    // `attributes` contains all constructor options
+  }
+});
+```

--- a/src/createModel.js
+++ b/src/createModel.js
@@ -8,6 +8,10 @@ export default function createModel(extend = {}) {
       super(...args);
 
       _.merge(this, extend);
+
+      if (typeof this.initialize === 'function') {
+        this.initialize(...args);
+      }
     }
   }
 

--- a/test/createModel.spec.js
+++ b/test/createModel.spec.js
@@ -41,4 +41,20 @@ describe('createModel', () => {
     expect('toJS' in myModelInstance).to.be.equal(true);
     expect(myModelInstance.toJS()).to.be.deep.equal(myAttributes);
   });
+
+  it('triggers initialize method with constructor options', () => {
+    const TestModel = createModel({
+      initialize(attributes) {
+        this.storedFromInitialize = attributes;
+      }
+    });
+
+    const testModel = new TestModel({
+      foo: 'bar'
+    });
+
+    expect(testModel.storedFromInitialize).to.deep.equal({
+      foo: 'bar'
+    });
+  });
 });


### PR DESCRIPTION
Like services and factories, a new `initialize()` lifecycle method has been added.

```js
// ./models/MyModelName.js
import { createModel } from 'frint';

export default createModel({
  initialize(attributes = {}) {
    // `attributes` contains all constructor options
  }
});
```