### PR TITLE
App lifecycle (destroy)

### DIFF
--- a/packages/frint-react/src/components/Region.js
+++ b/packages/frint-react/src/components/Region.js
@@ -132,7 +132,7 @@ export default React.createClass({
 
     if (this.rootApp) {
       this.state.listForRendering
-        .filter(item => item.multi === true)
+        .filter(item => item.multi)
         .forEach((item) => {
           this.rootApp.destroyWidget(
             item.name,

--- a/packages/frint-react/src/components/Region.js
+++ b/packages/frint-react/src/components/Region.js
@@ -60,6 +60,7 @@ export default React.createClass({
           this.state.list.forEach((item) => {
             const widgetName = item.name;
             const widgetWeight = item.weight;
+            const widgetMulti = item.multi;
             const existsInState = this.state.listForRendering.some((w) => {
               return w.name === widgetName;
             });
@@ -92,6 +93,7 @@ export default React.createClass({
                   name: widgetName,
                   weight: widgetWeight,
                   instance: widgetInstance,
+                  multi: widgetMulti,
                   Component: getMountableComponent(widgetInstance),
                 })
                 .sort((a, b) => {
@@ -130,6 +132,7 @@ export default React.createClass({
 
     if (this.rootApp) {
       this.state.listForRendering
+        .filter(item => item.multi === true)
         .forEach((item) => {
           this.rootApp.destroyWidget(
             item.name,

--- a/packages/frint-react/src/components/Region.js
+++ b/packages/frint-react/src/components/Region.js
@@ -49,6 +49,7 @@ export default React.createClass({
       return;
     }
 
+    this.rootApp = rootApp;
     const widgets$ = rootApp.getWidgets$(this.props.name, this.props.uniqueKey);
 
     this.subscription = widgets$.subscribe({
@@ -127,7 +128,16 @@ export default React.createClass({
       this.subscription.unsubscribe();
     }
 
-    // @TODO: clear instances
+    if (this.rootApp) {
+      this.state.listForRendering
+        .forEach((item) => {
+          this.rootApp.destroyWidget(
+            item.name,
+            this.props.name,
+            this.props.uniqueKey
+          );
+        });
+    }
   },
 
   render() {

--- a/packages/frint/README.md
+++ b/packages/frint/README.md
@@ -323,9 +323,10 @@ Core and Widget extend this class.
 ### Arguments
 
 1. `options` (`Object`)
-    * `options.name`: (`String` [required]): Name of your App
-    * `options.initialize`: (`Function` [optional]): Called when App is constructed
-    * `options.providers`: (`Array` [optional]): Array of provider objects
+    * `options.name`: (`String` [required]): Name of your App.
+    * `options.initialize`: (`Function` [optional]): Called when App is constructed.
+    * `options.beforeDestroy`: (`Function` [optional]): Called when App is about to be destroyed.
+    * `options.providers`: (`Array` [optional]): Array of provider objects.
 
 ### Returns
 
@@ -519,6 +520,22 @@ Instantiates the registered Widget class, (for the targetted region/regionKey if
 1. `region` (`String` [optional]): If you want the Widget of a specific region
 1. `regionKey` (`String` [optional]): If it is a multi-instance Widget, then the lookup can be scoped by region's keys.
 
-### Returns
+#### Returns
 
 `Array`: The updated collection of widgets.
+
+### app.destroyWidget
+
+> app.destroyWidget(name, region = null, regionKey = null)
+
+Destroys Widget instance.
+
+#### Arguments
+
+1. `name` (`String`): The name of the Widget that you are looking for
+1. `region` (`String` [optional]): If you want the Widget of a specific region
+1. `regionKey` (`String` [optional]): If it is a multi-instance Widget, then the lookup can be scoped by region's keys.
+
+#### Returns
+
+`void`.

--- a/packages/frint/package.json
+++ b/packages/frint/package.json
@@ -29,7 +29,7 @@
     "frint-plugin"
   ],
   "dependencies": {
-    "diyai": "^0.6.3",
+    "diyai": "^1.0.0",
     "lodash": "^4.13.1",
     "rxjs": "^5.2.0"
   },

--- a/packages/frint/src/App.js
+++ b/packages/frint/src/App.js
@@ -297,6 +297,10 @@ App.prototype.instantiateWidget = function instantiateWidget(name, region = null
 
 App.prototype.destroyWidget = function destroyWidget(name, region = null, regionKey = null) {
   const index = _.findIndex(this._widgetsCollection, (w) => {
+    if (!w || !w.App) {
+      return false;
+    }
+
     return w.App.frintAppName === name;
   });
 

--- a/packages/frint/src/App.spec.js
+++ b/packages/frint/src/App.spec.js
@@ -221,6 +221,21 @@ describe('frint  › App', function () {
     expect(called).to.equal(true);
   });
 
+  it('calls beforeDestroy, as passed in options', function () {
+    let called = false;
+
+    const app = new App({
+      name: 'MyApp',
+      beforeDestroy() {
+        called = true;
+      }
+    });
+    app.beforeDestroy();
+
+    expect(app.getOption('name')).to.equal('MyApp');
+    expect(called).to.equal(true);
+  });
+
   it('registers widgets', function () {
     const Core = createApp({ name: 'MyApp' });
     const Widget1 = createApp({ name: 'Widget1' });


### PR DESCRIPTION
## What's done

* When multi-instance Widgets are unmounted:
  * The instances are destroyed
  * And the root app also clears them from internal registry

This is done because multi-instance Widgets are directly dependent on repeating Regions. If Regions are unmounted, they become redundant and add to memory leakage.

## Usage

Nothing extra needs to be done from a developer's point of view, but a new `beforeDestroy` callback is now available:

```js
import { createApp } from 'frint';

const App = createApp({
  name: 'MyApp',

  initialize: function () {
    // called when the App is instantiated
  },

  beforeDestroy: function () {
    // called when App is about to be destroyed
  }
});
```