### PR TITLE
Migration guide updated to reflect monorepo

### DIFF
--- a/site/content/docs/migration/v1.md
+++ b/site/content/docs/migration/v1.md
@@ -12,7 +12,6 @@ But using old API would give you deprecated warnings, and they can be eliminated
 <!-- MarkdownTOC depth=1 autolink=true bracket=round -->
 
 - [app](#app)
-- [Creating Core Apps and Widgets](#creating-core-apps-and-widgets)
 - [Root components](#root-components)
 - [Store](#store)
 - [Services](#services)
@@ -36,32 +35,6 @@ Recommended equivalent methods for `App` instance, introduced in new API:
 | `app.dispatch(action)` | `app.get('store').dispatch(action)` |
 | `app.render`           | `app.get('component')`              |
 | `app.getWidgets()`     | `app.getWididgets$()`               |
-
-## Creating Core Apps and Widgets
-
-### `v0.x`
-
-```js
-import { createApp } from 'frint';
-
-const App = createApp({
-  name: 'MyCoreAppOrWidget'
-});
-```
-
-### `v1.x`
-
-```js
-import { createCore, createWidget } from 'frint';
-
-const CoreApp = createCore({
-  name: 'MyCoreApp'
-});
-
-const Widget = createWidget({
-  name: 'MyWidget'
-})
-```
 
 ## Root components
 
@@ -113,14 +86,13 @@ const store = app.getStore();
 
 ### `v1.x`
 
-Applies to both `createCore` and `createWidget` the same way.
-
 Stores are optional in `v1.x`:
 
 ```js
-import { createCore, createStore } from 'frint';
+import { createApp } from 'frint';
+import { createStore } from 'frint-store';
 
-const App = createCore({
+const App = createApp({
   name: 'MyApp',
   providers: [
     {
@@ -169,7 +141,7 @@ const foo = app.getService('foo');
 ### `v1.x`
 
 ```js
-import { createCore } from 'frint';
+import { createApp } from 'frint';
 
 // just a regular ES6-compatible class
 class FooService {
@@ -182,7 +154,7 @@ class FooService {
   }
 }
 
-const App = createCore({
+const App = createApp({
   name: 'MyApp',
   providers: [
     {
@@ -225,7 +197,7 @@ const bar = app.getFactory('bar');
 ### `v1.x`
 
 ```js
-import { createCore } from 'frint';
+import { createApp } from 'frint';
 
 // just a regular ES6-compatible class
 class BarFactory {
@@ -238,7 +210,7 @@ class BarFactory {
   }
 }
 
-const App = createCore({
+const App = createApp({
   name: 'MyApp',
   providers: [
     {
@@ -283,11 +255,11 @@ const baz = app.getModel('baz');
 ### `v1.x`
 
 ```js
-import { createModel, createCore } from 'frint';
+import { createModel, createApp } from 'frint';
 
 const BazModel = createModel({});
 
-const App = createCore({
+const App = createApp({
   name: 'MyApp',
   providers: [
     {
@@ -313,7 +285,7 @@ const baz = app.get('baz');
 ```js
 // ./components/Root.js
 import { mapToProps, createComponent } from 'frint';
-import { Observable } from 'rxjx';
+import { Observable } from 'rxjs';
 
 import { addTodo } from '../actions/todos';
 
@@ -361,12 +333,13 @@ The usage of `mapToProps` can be replaced with `observe`, along with a helper fu
 
 ```js
 // ./components/Root.js
-import { observe, streamProps, createComponent } from 'frint';
-import { Observable } from 'rxjx';
+import React from 'react';
+import { Observable } from 'rxjs';
+import { observe, streamProps } from 'frint-react';
 
 import { addTodo } from '../actions/todos';
 
-const Root = createComponent({
+const Root = React.createClass({
   render() {
     // ...
   }


### PR DESCRIPTION
## What's done

* Migration guide updated to import functions from the right packages
* Snippets don't enforce to use aliased functions `createCore` and `createWidget`
  * `createApp` is enough, like @alexmiranda suggested