### PR TITLE
Use forked `travix-di`, instead of `diyai`.

### DIFF
--- a/packages/frint/package.json
+++ b/packages/frint/package.json
@@ -29,9 +29,9 @@
     "frint-plugin"
   ],
   "dependencies": {
-    "diyai": "^1.0.0",
     "lodash": "^4.13.1",
-    "rxjs": "^5.2.0"
+    "rxjs": "^5.2.0",
+    "travix-di": "^1.0.0"
   },
   "bugs": {
     "url": "https://github.com/Travix-International/frint/issues"

--- a/packages/frint/src/App.js
+++ b/packages/frint/src/App.js
@@ -1,6 +1,6 @@
 import { BehaviorSubject, Observable } from 'rxjs';
 import _ from 'lodash';
-import { createContainer, resolveContainer } from 'diyai';
+import { createContainer, resolveContainer } from 'travix-di';
 
 function makeInstanceKey(region = null, regionKey = null, multi = false) {
   if (


### PR DESCRIPTION
## What's done

* Continuation of https://github.com/Travix-International/travix-di/pull/1
* Now gives @Travix-International members full control over the package that `frint` depends on