### PR TITLE
Drop plugin concept

### DIFF
--- a/packages/frint-compat/README.md
+++ b/packages/frint-compat/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/frint-compat.svg)](https://www.npmjs.com/package/frint-compat)
 
-> Backwards compatibility plugin
+> Backwards compatibility package for Frint
 
 Everything that you see here has been deprecated and should not be intentionally used.
 

--- a/packages/frint-compat/package.json
+++ b/packages/frint-compat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frint-compat",
   "version": "0.14.0",
-  "description": "Backwards compatibility plugin for Frint",
+  "description": "Backwards compatibility package for Frint",
   "main": "lib/index.js",
   "homepage": "https://github.com/Travix-International/frint/tree/master/packages/frint-compat",
   "scripts": {

--- a/packages/frint-compat/package.json
+++ b/packages/frint-compat/package.json
@@ -25,8 +25,7 @@
     "url": "https://travix.com"
   },
   "keywords": [
-    "frint",
-    "frint-plugin"
+    "frint"
   ],
   "dependencies": {
     "frint": "^0.14.0",

--- a/packages/frint-model/package.json
+++ b/packages/frint-model/package.json
@@ -25,8 +25,7 @@
     "url": "https://travix.com"
   },
   "keywords": [
-    "frint",
-    "frint-plugin"
+    "frint"
   ],
   "dependencies": {
     "lodash": "^4.13.1"

--- a/packages/frint-model/package.json
+++ b/packages/frint-model/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frint-model",
   "version": "0.14.0",
-  "description": "Model plugin for Frint",
+  "description": "Model package for Frint",
   "main": "lib/index.js",
   "homepage": "https://github.com/Travix-International/frint/tree/master/packages/frint-model",
   "scripts": {

--- a/packages/frint-react-server/README.md
+++ b/packages/frint-react-server/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/frint-react-server.svg)](https://www.npmjs.com/package/frint-react-server)
 
-> Server-side React plugin for Frint
+> Server-side React package for Frint
 
 <!-- MarkdownTOC autolink=true bracket=round -->
 

--- a/packages/frint-react-server/package.json
+++ b/packages/frint-react-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frint-react-server",
   "version": "0.14.0",
-  "description": "Server-side React plugin for Frint",
+  "description": "Server-side React package for Frint",
   "main": "lib/index.js",
   "homepage": "https://github.com/Travix-International/frint/tree/master/packages/frint-react-server",
   "scripts": {

--- a/packages/frint-react-server/package.json
+++ b/packages/frint-react-server/package.json
@@ -25,8 +25,7 @@
     "url": "https://travix.com"
   },
   "keywords": [
-    "frint",
-    "frint-plugin"
+    "frint"
   ],
   "devDependencies": {
     "frint": "^0.14.0",

--- a/packages/frint-react/README.md
+++ b/packages/frint-react/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/frint-react.svg)](https://www.npmjs.com/package/frint-react)
 
-> React plugin of Frint
+> React package for Frint
 
 <!-- MarkdownTOC autolink=true bracket=round -->
 

--- a/packages/frint-react/package.json
+++ b/packages/frint-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frint-react",
   "version": "0.14.0",
-  "description": "React plugin for Frint",
+  "description": "React package for Frint",
   "main": "lib/index.js",
   "homepage": "https://github.com/Travix-International/frint/tree/master/packages/frint-react",
   "scripts": {

--- a/packages/frint-react/package.json
+++ b/packages/frint-react/package.json
@@ -25,8 +25,7 @@
     "url": "https://travix.com"
   },
   "keywords": [
-    "frint",
-    "frint-plugin"
+    "frint"
   ],
   "dependencies": {
     "lodash": "^4.13.1",

--- a/packages/frint-store/README.md
+++ b/packages/frint-store/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/frint-store.svg)](https://www.npmjs.com/package/frint-store)
 
-> Store plugin of Frint
+> Store package of Frint
 
 <!-- MarkdownTOC autolink=true bracket=round -->
 

--- a/packages/frint-store/package.json
+++ b/packages/frint-store/package.json
@@ -25,8 +25,7 @@
     "url": "https://travix.com"
   },
   "keywords": [
-    "frint",
-    "frint-plugin"
+    "frint"
   ],
   "dependencies": {
     "lodash": "^4.13.1",

--- a/packages/frint-store/package.json
+++ b/packages/frint-store/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frint-store",
   "version": "0.14.0",
-  "description": "Store plugin for Frint",
+  "description": "Store package for Frint",
   "main": "lib/index.js",
   "homepage": "https://github.com/Travix-International/frint/tree/master/packages/frint-store",
   "scripts": {

--- a/packages/frint-test-utils/package.json
+++ b/packages/frint-test-utils/package.json
@@ -25,8 +25,7 @@
     "url": "https://travix.com"
   },
   "keywords": [
-    "frint",
-    "frint-plugin"
+    "frint"
   ],
   "dependencies": {
     "jsdom": "^9.11.0"

--- a/packages/frint-test-utils/package.json
+++ b/packages/frint-test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frint-test-utils",
   "version": "0.14.0",
-  "description": "Test utilities Frint",
+  "description": "Test utilities for Frint",
   "main": "lib/index.js",
   "homepage": "https://github.com/Travix-International/frint/tree/master/packages/frint-test-utils",
   "scripts": {

--- a/packages/frint/README.md
+++ b/packages/frint/README.md
@@ -12,9 +12,7 @@
   - [Usage](#usage)
   - [Creating and registering widgets](#creating-and-registering-widgets)
   - [Understanding Providers](#understanding-providers)
-  - [Plugins](#plugins)
 - [API](#api)
-  - [use](#use)
   - [App](#app)
   - [createApp](#createapp)
   - [createCore](#createcore)
@@ -54,7 +52,6 @@ Via [unpkg](https://unpkg.com) CDN:
 * `Core`: The root app, that renders to DOM directly.
 * `Widget`: Apps that register themselves to Core.
 * `Provider`: Dependency for your apps (Core and Widgets).
-* `Plugin`: Modules that extend the core framework.
 
 ## Usage
 
@@ -263,50 +260,9 @@ app.get('theNameOfTheApp') === 'MyCoreApp';
 app.getWidgetInstance('MyWidget').get('theNameOfTheApp') === 'MyWidget';
 ```
 
-## Plugins
-
-Plugins help extend the core of the framework.
-
-### Installation
-
-Plugins can be installed as follows:
-
-```js
-const Frint = require('frint');
-const FooPlugin = require('frint-plugin-foo');
-
-Frint.use(FooPlugin);
-```
-
-### Development
-
-A plugin in its simplest form, is an object exposing a `install` function. The function accepts `Frint`, which can be extended further from there.
-
-```js
-// frint-plugin-foo/index.js
-module.exports = {
-  install: function (Frint, options = {}) {
-    // extend `Frint` here
-  }
-};
-```
-
 ---
 
 # API
-
-## use
-
-> use(Plugin, options = {})
-
-### Arguments
-
-1. `Plugin` (`Object` [required])
-2. `options` (`Object` [optional])
-
-### Returns
-
-`void`
 
 ## App
 

--- a/packages/frint/package.json
+++ b/packages/frint/package.json
@@ -25,8 +25,7 @@
     "url": "https://travix.com"
   },
   "keywords": [
-    "frint",
-    "frint-plugin"
+    "frint"
   ],
   "dependencies": {
     "lodash": "^4.13.1",

--- a/packages/frint/src/index.js
+++ b/packages/frint/src/index.js
@@ -10,12 +10,4 @@ const Frint = {
   createWidget,
 };
 
-Frint.use = function use(Plugin, ...args) {
-  if (typeof Plugin.install !== 'function') {
-    throw new Error('Plugin does not have any `install` option.');
-  }
-
-  return Plugin.install(Frint, ...args);
-};
-
 export default Frint;


### PR DESCRIPTION
## What's done

* Drops the concept for plugins via `Frint.use()`
* Because everything is coming from separate npm packages already, not requiring any mutations