### PR TITLE
Test observed components with enzyme

### DIFF
--- a/packages/frint-react/src/components/observe.spec.js
+++ b/packages/frint-react/src/components/observe.spec.js
@@ -4,6 +4,7 @@ import { expect } from 'chai';
 import { Observable } from 'rxjs';
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { mount } from 'enzyme';
 
 import observe from './observe';
 import Provider from './Provider';
@@ -102,5 +103,54 @@ describe('frint-react › components › observe', function () {
     );
 
     expect(document.getElementById('name').innerHTML).to.equal('FakeApp');
+  });
+
+  it('can be tested with enzyme', function () {
+    const ChildComponent = React.createClass({
+      render() {
+        return <p>I am a child.</p>
+      }
+    });
+
+    const Component = React.createClass({
+      render() {
+        return (
+          <div>
+            <p id="name">{this.props.name}</p>
+
+            <ChildComponent />
+          </div>
+        );
+      }
+    });
+
+    const ObservedComponent = observe(function (app) {
+      return Observable
+        .of(app.getOption('name'))
+        .map(name => ({ name }));
+    })(Component);
+
+    const fakeApp = {
+      getOption() {
+        return 'ShallowApp';
+      }
+    };
+
+    const ComponentToRender = React.createClass({
+      render() {
+        return (
+          <Provider app={fakeApp}>
+            <ObservedComponent {...this.props} />
+          </Provider>
+        );
+      }
+    });
+
+    const wrapper = mount(<ComponentToRender />);
+    expect(wrapper.find(ObservedComponent)).to.have.length(1);
+    expect(wrapper.find(ObservedComponent)).to.have.length(1);
+    expect(wrapper.find(ChildComponent)).to.have.length(1);
+    expect(wrapper.find('#name')).to.have.length(1);
+    expect(wrapper.text()).to.contain('I am a child');
   });
 });

--- a/packages/frint-react/src/components/observe.spec.js
+++ b/packages/frint-react/src/components/observe.spec.js
@@ -108,7 +108,7 @@ describe('frint-react › components › observe', function () {
   it('can be tested with enzyme', function () {
     const ChildComponent = React.createClass({
       render() {
-        return <p>I am a child.</p>
+        return <p>I am a child.</p>;
       }
     });
 


### PR DESCRIPTION
## What's done

Previously we tested server-side rendering with observed components in PR #128 (it passed).

This PR shows how enzyme can be used for testing observed components too.

### Note about shallow rendering

@alexmiranda was right about shallow rendering not working. Instead of shallow, I used DOM rendering with enzyme, which has the same API as shallow rendering.

It would be nice to be able to use shallow rendering for testing too, but I don't know why that's not working at this moment.

### Differences in enzyme usage

```js
// shallow - which doesn't work
import { shallow } from 'enzyme';
const wrapper = shallow(<MyObservedComponent />);
expect(wrapper.find('#selector')).to.have.length(1);

// DOM - works for us
import { mount } from 'enzyme';
const wrapper = mount(<MyObservedComponent />);
expect(wrapper.find('#selector')).to.have.length(1);
```

## Links

* Shallow rendering: http://airbnb.io/enzyme/docs/api/shallow.html
* DOM rendering: http://airbnb.io/enzyme/docs/api/mount.html