### PR TITLE
App hierarchy

### DIFF
--- a/packages/frint-compat/src/createApp.spec.js
+++ b/packages/frint-compat/src/createApp.spec.js
@@ -103,7 +103,9 @@ describe('frint-compat › createApp', function () {
       }
     });
 
-    const widget = new WidgetApp();
+    const widget = new WidgetApp({
+      parentApp: window.app,
+    });
 
     expect(widget.getModel('baz').getName()).to.equal('Baz');
   });
@@ -131,7 +133,9 @@ describe('frint-compat › createApp', function () {
       }
     });
 
-    const widget = new WidgetApp();
+    const widget = new WidgetApp({
+      parentApp: window.app,
+    });
 
     expect(widget.getFactory('bar').getName()).to.equal('TestFactory');
   });
@@ -166,7 +170,9 @@ describe('frint-compat › createApp', function () {
       }
     });
 
-    const widget = new WidgetApp();
+    const widget = new WidgetApp({
+      parentApp: window.app,
+    });
 
     expect(widget.getService('foo').getName()).to.equal('TestService');
   });
@@ -317,11 +323,12 @@ describe('frint-compat › createApp', function () {
     expect(foo).to.equal('bar');
   });
 
-  it('throws error if setRegion is called without a root app', function () {
-    const widget = new WidgetApp();
+  // NOTE: setRegion will never be called in v1.x
+  // it('throws error if setRegion is called without a root app', function () {
+  //   const widget = new WidgetApp();
 
-    expect(() => widget.setRegion('sidebar')).to.throw(/No root app instance available/);
-  });
+  //   expect(() => widget.setRegion('sidebar')).to.throw(/No root app instance available/);
+  // });
 
   it('throws error if wrong Model class is given', function () {
     expect(function () {

--- a/packages/frint/README.md
+++ b/packages/frint/README.md
@@ -313,7 +313,23 @@ The `App` instance (either Root App or Widget):
 
 #### Returns
 
-Gives you the Root App instance.
+`App`: Gives you the Root App instance.
+
+### app.getParentApp
+
+> app.getParentApp()
+
+#### Returns
+
+`App`: Gives you the immediate Parent App instance.
+
+### app.getParentApps
+
+> app.getParentApps()
+
+### Returns
+
+`Array`: Array of parent apps, with immediate parent app as first element and the root app being the last.
 
 ### app.getProviders
 

--- a/packages/frint/src/App.js
+++ b/packages/frint/src/App.js
@@ -26,7 +26,7 @@ function makeInstanceKey(region = null, regionKey = null, multi = false) {
 function App(opts = {}) {
   this.options = {
     name: null,
-    rootApp: null,
+    parentApp: null,
     providers: [],
 
     providerNames: {
@@ -34,6 +34,7 @@ function App(opts = {}) {
       container: 'container',
       store: 'store',
       app: 'app',
+      parentApp: 'parentApp',
       rootApp: 'rootApp',
       region: 'region',
     },
@@ -54,6 +55,7 @@ function App(opts = {}) {
   // container
   const Container = createContainer([
     { name: this.options.providerNames.app, useDefinedValue: this },
+    { name: this.options.providerNames.parentApp, useDefinedValue: this.options.parentApp },
     { name: this.options.providerNames.rootApp, useDefinedValue: this.options.rootApp },
   ], {
     containerKey: this.options.providerNames.container,
@@ -141,13 +143,21 @@ App.prototype.getContainer = function getContainer() {
 };
 
 App.prototype.getRootApp = function getRootApp() {
-  const rootApp = this.get(this.getOption('providerNames.rootApp'));
+  function findRoot(app) {
+    const parentApp = app.getParentApp();
 
-  if (rootApp) {
-    return rootApp;
+    if (!parentApp) {
+      return app;
+    }
+
+    return findRoot(parentApp);
   }
 
-  return this;
+  return findRoot(this);
+};
+
+App.prototype.getParentApp = function getParentApp() {
+  return this.options.parentApp || null;
 };
 
 App.prototype.getOption = function getOption(key) {

--- a/packages/frint/src/App.spec.js
+++ b/packages/frint/src/App.spec.js
@@ -20,6 +20,31 @@ describe('frint  › App', function () {
     expect(app.getOption('name')).to.equal('MyApp');
   });
 
+  it('gets parent and root app', function () {
+    const rootApp = new App({
+      name: 'RootApp',
+    });
+
+    const childApp = new App({
+      name: 'ChildApp',
+      parentApp: rootApp,
+    });
+
+    const grandchildApp = new App({
+      name: 'GrandchildApp',
+      parentApp: childApp,
+    });
+
+    expect(rootApp.getOption('name')).to.equal('RootApp');
+    expect(childApp.getOption('name')).to.equal('ChildApp');
+
+    expect(childApp.getParentApp()).to.deep.equal(rootApp);
+    expect(childApp.getRootApp()).to.deep.equal(rootApp);
+
+    expect(grandchildApp.getParentApp()).to.deep.equal(childApp);
+    expect(grandchildApp.getRootApp()).to.deep.equal(rootApp);
+  });
+
   it('registers providers with direct values', function () {
     const app = new App({
       name: 'MyApp',

--- a/packages/frint/src/App.spec.js
+++ b/packages/frint/src/App.spec.js
@@ -37,12 +37,28 @@ describe('frint  › App', function () {
 
     expect(rootApp.getOption('name')).to.equal('RootApp');
     expect(childApp.getOption('name')).to.equal('ChildApp');
+    expect(rootApp.getParentApps()).to.deep.equal([]);
 
     expect(childApp.getParentApp()).to.deep.equal(rootApp);
     expect(childApp.getRootApp()).to.deep.equal(rootApp);
+    expect(
+      childApp
+        .getParentApps()
+        .map(x => x.options.name)
+    ).to.deep.equal([
+      'RootApp'
+    ]);
 
     expect(grandchildApp.getParentApp()).to.deep.equal(childApp);
     expect(grandchildApp.getRootApp()).to.deep.equal(rootApp);
+    expect(
+      grandchildApp
+        .getParentApps()
+        .map(x => x.options.name)
+    ).to.deep.equal([
+      'ChildApp',
+      'RootApp',
+    ]);
   });
 
   it('registers providers with direct values', function () {
@@ -124,14 +140,14 @@ describe('frint  › App', function () {
     expect(app.get('baz').getValue()).to.equal('bazValue, fooValue, barValue, fooValue');
   });
 
-  it('returns services from Core that are cascaded', function () {
+  it('returns services from Root that are cascaded', function () {
     class ServiceC {
       getValue() {
         return 'serviceC';
       }
     }
 
-    const Core = createApp({
+    const Root = createApp({
       name: 'MyApp',
       providers: [
         {
@@ -170,9 +186,10 @@ describe('frint  › App', function () {
         }
       ],
     });
+
     const Widget1 = createApp({ name: 'Widget1' });
 
-    const app = new Core();
+    const app = new Root();
     app.registerWidget(Widget1);
 
     const widget = app.getWidgetInstance('Widget1');
@@ -186,11 +203,11 @@ describe('frint  › App', function () {
     expect(app.get('serviceF')).to.equal(null);
   });
 
-  it('returns null when service is non-existent in both Widget and Core', function () {
-    const Core = createApp({ name: 'MyApp' });
+  it('returns null when service is non-existent in both Widget and Root', function () {
+    const Root = createApp({ name: 'MyApp' });
     const Widget1 = createApp({ name: 'Widget1' });
 
-    const app = new Core();
+    const app = new Root();
     app.registerWidget(Widget1);
 
     const serviceA = app
@@ -262,10 +279,10 @@ describe('frint  › App', function () {
   });
 
   it('registers widgets', function () {
-    const Core = createApp({ name: 'MyApp' });
+    const Root = createApp({ name: 'MyApp' });
     const Widget1 = createApp({ name: 'Widget1' });
 
-    const app = new Core();
+    const app = new Root();
 
     app.registerWidget(Widget1, {
       regions: ['sidebar'],
@@ -276,10 +293,10 @@ describe('frint  › App', function () {
   });
 
   it('registers widgets, by overriding options', function () {
-    const Core = createApp({ name: 'MyApp' });
+    const Root = createApp({ name: 'MyApp' });
     const Widget1 = createApp({ name: 'Widget1' });
 
-    const app = new Core();
+    const app = new Root();
 
     app.registerWidget(Widget1, {
       name: 'WidgetOne',
@@ -291,10 +308,10 @@ describe('frint  › App', function () {
   });
 
   it('registers widgets', function () {
-    const Core = createApp({ name: 'MyApp' });
+    const Root = createApp({ name: 'MyApp' });
     const Widget1 = createApp({ name: 'Widget1' });
 
-    const app = new Core();
+    const app = new Root();
 
     app.registerWidget(Widget1, {
       regions: ['sidebar'],
@@ -305,10 +322,10 @@ describe('frint  › App', function () {
   });
 
   it('streams registered widgets as a collection', function (done) {
-    const Core = createApp({ name: 'MyApp' });
+    const Root = createApp({ name: 'MyApp' });
     const Widget1 = createApp({ name: 'Widget1' });
 
-    const app = new Core();
+    const app = new Root();
 
     app.registerWidget(Widget1, {
       regions: ['sidebar'],
@@ -325,10 +342,10 @@ describe('frint  › App', function () {
   });
 
   it('streams registered widgets as a collection, with region filtering', function (done) {
-    const Core = createApp({ name: 'MyApp' });
+    const Root = createApp({ name: 'MyApp' });
     const Widget1 = createApp({ name: 'Widget1' });
 
-    const app = new Core();
+    const app = new Root();
 
     app.registerWidget(Widget1, {
       regions: ['sidebar'],
@@ -345,10 +362,10 @@ describe('frint  › App', function () {
   });
 
   it('gets widget once available (that will be available in future)', function (done) {
-    const Core = createApp({ name: 'MyApp' });
+    const Root = createApp({ name: 'MyApp' });
     const Widget1 = createApp({ name: 'Widget1' });
 
-    const app = new Core();
+    const app = new Root();
 
     app.getWidgetOnceAvailable$('Widget1')
       .subscribe(function (widget) {
@@ -361,10 +378,10 @@ describe('frint  › App', function () {
   });
 
   it('gets widget once available (that is already available)', function (done) {
-    const Core = createApp({ name: 'MyApp' });
+    const Root = createApp({ name: 'MyApp' });
     const Widget1 = createApp({ name: 'Widget1' });
 
-    const app = new Core();
+    const app = new Root();
     app.registerWidget(Widget1);
 
     app.getWidgetOnceAvailable$('Widget1')
@@ -376,11 +393,11 @@ describe('frint  › App', function () {
   });
 
   it('gets widget scoped by region', function () {
-    const Core = createApp({ name: 'MyApp' });
+    const Root = createApp({ name: 'MyApp' });
     const Widget1 = createApp({ name: 'Widget1' });
     const Widget2 = createApp({ name: 'Widget2' });
 
-    const app = new Core();
+    const app = new Root();
     app.registerWidget(Widget1, {
       regions: ['sidebar'],
     });
@@ -400,10 +417,10 @@ describe('frint  › App', function () {
   });
 
   it('throws error when registering same Widget twice', function () {
-    const Core = createApp({ name: 'MyApp' });
+    const Root = createApp({ name: 'MyApp' });
     const Widget1 = createApp({ name: 'Widget1' });
 
-    const app = new Core();
+    const app = new Root();
     app.registerWidget(Widget1);
 
     expect(() => {
@@ -412,10 +429,10 @@ describe('frint  › App', function () {
   });
 
   it('checks for widget instance availability', function () {
-    const Core = createApp({ name: 'MyApp' });
+    const Root = createApp({ name: 'MyApp' });
     const Widget1 = createApp({ name: 'Widget1' });
 
-    const app = new Core();
+    const app = new Root();
     expect(app.hasWidgetInstance('blah')).to.equal(false);
 
     app.registerWidget(Widget1);
@@ -423,8 +440,8 @@ describe('frint  › App', function () {
   });
 
   it('throws error when trying to instantiate non-existent Widget', function () {
-    const Core = createApp({ name: 'MyApp' });
-    const app = new Core();
+    const Root = createApp({ name: 'MyApp' });
+    const app = new Root();
 
     expect(() => {
       app.instantiateWidget('blah');


### PR DESCRIPTION
## What's done

* Parent/Child relationship between Apps is now fully hierarchical
  * We currently only have `Root App ==> Widget` hierarchy
  * With this PR, we now have `Root App ==> As ==> Many ==> Apps ==> Widget`
* More tests written
* Docs provided
* Does not change the behaviour of 1.x in any way, and in fact makes it purer

## Future

This PR now makes way for things like: 

* Routing system with nested views
* Concept of Shell App that we discussed before (for PWA), which can closely work with Service Workers