### PR TITLE
frint-compat: fixes for readableApps.

### DIFF
--- a/packages/frint-compat/src/extendApp.js
+++ b/packages/frint-compat/src/extendApp.js
@@ -200,7 +200,7 @@ export default function extendApp(Frint, FrintStore, FrintReact) {
       return null;
     }
 
-    return w.instances.default.getStore();
+    return w.getStore();
   };
 
   App.prototype.getModel = function getModel(name) {
@@ -259,7 +259,7 @@ export default function extendApp(Frint, FrintStore, FrintReact) {
 
   App.prototype.readStateFrom = function readStateFrom(appNames = []) {
     console.log('[DEPRECATED] `readStateFrom` has been deprecated.');
-    this.readableApps = appNames;
+    this.options.readableApps = appNames;
   };
 
   ['beforeMount', 'afterMount', 'beforeUnmount'].forEach((hookName) => {

--- a/packages/frint-compat/src/mapToProps.js
+++ b/packages/frint-compat/src/mapToProps.js
@@ -45,8 +45,9 @@ export default function makeMapToProps({ observe, streamProps }) {
           props.set(options.shared({}));
 
           const sharedStateObservables = [];
+          const readableApps = app.options.readableApps || [];
 
-          app.readableApps.forEach((readableAppName) => {
+          readableApps.forEach((readableAppName) => {
             sharedStateObservables.push(
               app.getWidgetOnceAvailable$(readableAppName)
                 .concatMap((readableApp) => {


### PR DESCRIPTION
## What's done

* Fix for shared state in old `mapToProps`