### PR TITLE
Add search functionality with Algolia

### DIFF
--- a/site/partials/assets.html
+++ b/site/partials/assets.html
@@ -4,11 +4,22 @@
 
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/themes/prism-solarizedlight.min.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css" />
 <link rel="stylesheet" href="/css/site.css" />
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/prism.min.js"></script>
 <script src="/js/site.js"></script>
+
+<script type="text/javascript" src="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js"></script>
+<script type="text/javascript">
+docsearch({
+  apiKey: '897a7279c47670a5c4b474ee84350387',
+  indexName: 'frint.js',
+  inputSelector: '#doc-search-text-box',
+  debug: false // Set debug to true if you want to inspect the dropdown
+});
+</script>
 
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/site/partials/navLinks.html
+++ b/site/partials/navLinks.html
@@ -20,3 +20,14 @@
     About
   </a>
 </div>
+
+<div class="nav-right">
+  <div class="field nav-item">
+    <p class="control has-icon">
+      <input id="doc-search-text-box" class="input" type="text" placeholder="Search...">
+      <span class="icon is-small">
+        <i class="fa fa-search"></i>
+      </span>
+    </p>
+  </div>
+</div>


### PR DESCRIPTION
This is what it looks like, on the home page

![image](https://cloud.githubusercontent.com/assets/1122274/24471729/4d970230-14c3-11e7-8f90-47034a1af5e2.png)

![image](https://cloud.githubusercontent.com/assets/1122274/24471734/5287eed0-14c3-11e7-972e-cd06f6281e89.png)

On other pages:

![image](https://cloud.githubusercontent.com/assets/1122274/24471739/57444a18-14c3-11e7-89ff-5110ac65b870.png)

![image](https://cloud.githubusercontent.com/assets/1122274/24471743/59ec8604-14c3-11e7-9671-b1f977feca07.png)

Inside the search popup the little underlines are blue, but I couldn't change them with the recommended styles (https://community.algolia.com/docsearch/documentation), so probably we'd have to dig deeper to adjust that.
Please tell if anything should be done differently, and feel free to jump in and change the styles if you'd like to change the looks.