### PR TITLE
Preset for Travix

### DIFF
--- a/packages/frint-preset-travix/README.md
+++ b/packages/frint-preset-travix/README.md
@@ -1,0 +1,26 @@
+# frint-preset-travix
+
+[![npm](https://img.shields.io/npm/v/frint-preset-travix.svg)](https://www.npmjs.com/package/frint-preset-travix)
+
+> Frint preset for Travix
+
+Installs all the Frint packages that Travix needs.
+
+**Note**: This package may be extracted out of the monorepo later.
+
+<!-- MarkdownTOC autolink=true bracket=round -->
+
+- [Guide](#guide)
+  - [Installation](#installation)
+
+<!-- /MarkdownTOC -->
+
+---
+
+# Guide
+
+## Installation
+
+```
+$ npm install --save frint-preset-travix
+```

--- a/packages/frint-preset-travix/package.json
+++ b/packages/frint-preset-travix/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "frint-preset-travix",
+  "version": "1.2.0",
+  "description": "Frint preset for Travix",
+  "homepage": "https://github.com/Travix-International/frint/tree/master/packages/frint-preset-travix",
+  "scripts": {
+    "lint": "echo \"Nothing to lint\"",
+    "transpile": "echo \"Nothing to transpile\"",
+    "test": "echo \"Nothing to test\"",
+    "cover:run": "echo \"Nothing to cover\"",
+    "cover:report": "echo \"Nothing to report\"",
+    "cover": "npm run cover:run && npm run cover:report",
+    "dist:lib": "echo \"Nothing to build\"",
+    "dist:min": "echo \"Nothing to minify\"",
+    "dist": "npm run dist:lib && npm run dist:min",
+    "prepublish": "echo \"Nothing to process\""
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Travix-International/frint.git"
+  },
+  "author": {
+    "name": "Travix International B.V.",
+    "url": "https://travix.com"
+  },
+  "keywords": [
+    "frint",
+    "frint-preset"
+  ],
+  "dependencies": {
+    "frint": "^1.2.0",
+    "frint-model": "^1.0.1",
+    "frint-store": "^1.0.0",
+    "frint-react": "^1.2.0",
+    "frint-react-server": "^1.2.0",
+    "frint-test-utils": "^1.0.0",
+    "frint-compat": "^1.2.0"
+  },
+  "bugs": {
+    "url": "https://github.com/Travix-International/frint/issues"
+  },
+  "license": "MIT"
+}


### PR DESCRIPTION
## What's done

* New `frint-preset-travix` package for installing all Frint packages in one go.
* The preset will take care of versioning for all the packages for us.

The primary reason for keeping it in the monorepo is Lerna's feature of automatically updating the version numbers in `package.json` on every new release.

And instead of manually updating all the package's versions in our private repositories later, we only need to update to latest preset every time.

It may be extracted out into a separate repository in future.