### PR TITLE
frint-cli: fix for `init` by removing extra space from command

### DIFF
--- a/packages/frint-cli/commands/init.js
+++ b/packages/frint-cli/commands/init.js
@@ -39,7 +39,7 @@ module.exports = createApp({
 
           const cmds = [
             `mkdir -p ${dir}`,
-            `curl https://codeload.github.com/Travix-International/frint/tar.gz/master | tar -xz -C ${dir} --strip=3 frint-master/examples/ ${example}`,
+            `curl https://codeload.github.com/Travix-International/frint/tar.gz/master | tar -xz -C ${dir} --strip=3 frint-master/examples/${example}`,
           ];
 
           deps.console.log('Initializing...');


### PR DESCRIPTION
## What's done

Fixes `$ frint init`.