### PR TITLE
Fix for migration guide typos

### DIFF
--- a/site/content/docs/migration/v1.md
+++ b/site/content/docs/migration/v1.md
@@ -14,6 +14,7 @@ But using old API would give you deprecated warnings, and they can be eliminated
 - [app](#app)
 - [Component](#component)
 - [Root components](#root-components)
+- [PropTypes](#proptypes)
 - [Store](#store)
 - [Services](#services)
 - [Factories](#factories)
@@ -32,7 +33,7 @@ Recommended equivalent methods for `App` instance, introduced in new API:
 | `app.getFactory(name)` | `app.get(factoryName)`              |
 | `app.getModel(name)`   | `app.get(modelName)`                |
 | `app.getStore()`       | `app.get('store')`                  |
-| `app.getSate$()`       | `app.get('store').getState$()`      |
+| `app.getState$()`      | `app.get('store').getState$()`      |
 | `app.dispatch(action)` | `app.get('store').dispatch(action)` |
 | `app.render`           | `app.get('component')`              |
 | `app.getWidgets()`     | `app.getApps$()`                    |
@@ -96,6 +97,28 @@ const App = createApp({
     }
   ]
 });
+```
+
+## PropTypes
+
+### `v0.x`
+
+```js
+import { PropTypes } from 'frint';
+```
+
+### `v1.x`
+
+In React v0.14:
+
+```js
+import { PropTypes } from 'react';
+```
+
+To keep things compatible with React v15+:
+
+```js
+import PropTypes from 'prop-types';
 ```
 
 ## Store

--- a/site/content/docs/migration/v1.md
+++ b/site/content/docs/migration/v1.md
@@ -56,6 +56,8 @@ const Root = createComponent({
 
 ### `v1.x`
 
+Now we use React directly:
+
 ```js
 import React, { Component } from 'react';
 
@@ -67,6 +69,14 @@ class Root extends Component {
   }
 }
 ```
+
+**Note**: Remember that the lifecycle methods in Components need to follow React's API too now:
+
+| v0.x - Frint createComponent | v1.x - React Component |
+|------------------------------|------------------------|
+| `beforeMount`                | `componentWillMount`   |
+| `afterMount`                 | `componentDidMount`    |
+| `beforeUnmount`              | `componentWillUnmount` |
 
 ## Root components
 


### PR DESCRIPTION
## What's done

* Migration guide typos fixed
* Added docs for `PropTypes` migration
* Added note for Component lifecycle methods