### PR TITLE
frint-router-react: fix lint errors

### DIFF
--- a/packages/frint-router-react/src/Route.js
+++ b/packages/frint-router-react/src/Route.js
@@ -1,10 +1,22 @@
+/* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { getMountableComponent } from 'frint-react';
+/* eslint-enable import/no-extraneous-dependencies */
 
 export default class Router extends React.Component {
   static contextTypes = {
     app: PropTypes.object.isRequired
+  };
+
+  static propTypes = {
+    computedRoute: PropTypes.object,
+    path: PropTypes.string,
+    exact: PropTypes.bool,
+    component: PropTypes.node,
+    getComponent: PropTypes.func,
+    app: PropTypes.func,
+    getApp: PropTypes.func,
   };
 
   constructor(...args) {
@@ -31,7 +43,7 @@ export default class Router extends React.Component {
     }
   }
 
-  componentDidMount() {
+  componentWillMount() {
     // match
     if (this.props.computedRoute) {
       this.setState({
@@ -60,7 +72,8 @@ export default class Router extends React.Component {
       // async component
       this.props.getComponent((err, component) => {
         if (err) {
-          return console.error(err);
+          console.error(err);
+          return;
         }
 
         this.setState({
@@ -80,7 +93,8 @@ export default class Router extends React.Component {
       // async App
       this.props.getApp((err, RouteApp) => {
         if (err) {
-          return console.error(err);
+          console.error(err);
+          return;
         }
 
         this.routeApp = new RouteApp({

--- a/packages/frint-router-react/src/Switch.js
+++ b/packages/frint-router-react/src/Switch.js
@@ -1,8 +1,7 @@
-import _ from 'lodash';
+/* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
 import PropTypes from 'prop-types';
-
-import Route from './Route';
+/* eslint-enable import/no-extraneous-dependencies */
 
 export default class Switch extends React.Component {
   static contextTypes = {


### PR DESCRIPTION
Hopefully, I got the Route propTypes correctly. Please check.

Renamed componentDidMount to componentWillMount, because of this.setState() inside, which would cause new render right after the component did mount.

Decided to keep console.error() just as a reminder that we need to handle errors somehow.