### PR TITLE
frint: new `app.getName` method

### DIFF
--- a/examples/kitchensink/core/components/Root.js
+++ b/examples/kitchensink/core/components/Root.js
@@ -97,6 +97,6 @@ export default observe(function (app) {
       };
     }, {
       // start with these props
-      appName: app.getOption('name'),
+      appName: app.getName(),
     });
 })(Root);

--- a/examples/kitchensink/core/services/Bar.js
+++ b/examples/kitchensink/core/services/Bar.js
@@ -4,6 +4,6 @@ export default class Bar {
   }
 
   getAppName() {
-    return this.app.getOption('name');
+    return this.app.getName();
   }
 }

--- a/examples/kitchensink/core/services/Baz.js
+++ b/examples/kitchensink/core/services/Baz.js
@@ -4,6 +4,6 @@ export default class Baz {
   }
 
   getAppName() {
-    return this.app.getOption('name');
+    return this.app.getName();
   }
 }

--- a/examples/kitchensink/core/services/Foo.js
+++ b/examples/kitchensink/core/services/Foo.js
@@ -4,6 +4,6 @@ export default class Foo {
   }
 
   getAppName() {
-    return this.app.getOption('name');
+    return this.app.getName();
   }
 }

--- a/packages/frint-compat/src/createApp.spec.js
+++ b/packages/frint-compat/src/createApp.spec.js
@@ -55,7 +55,7 @@ describe('frint-compat › createApp', function () {
     const app = new CoreApp();
 
     expect(app).to.be.instanceof(CoreApp);
-    expect(app.getOption('name')).to.equal('CoreAppName');
+    expect(app.getName()).to.equal('CoreAppName');
   });
 
   it('throws error if instantiated without name option', function () {

--- a/packages/frint-compat/src/mapToProps.spec.js
+++ b/packages/frint-compat/src/mapToProps.spec.js
@@ -57,7 +57,7 @@ describe('frint-compat › components › mapToProps', function () {
     const TestRootComponent = mapToProps({
       app(app) {
         return {
-          name: app.getOption('name')
+          name: app.getName()
         };
       },
       services: {
@@ -212,7 +212,7 @@ describe('frint-compat › components › mapToProps', function () {
       return (dispatch, getState, { app }) => {
         const currentState = getState();
 
-        if (app.getOption('name') === 'Test') {
+        if (app.getName() === 'Test') {
           const newValue = currentState.counter.value + step;
 
           dispatch(setCounter(newValue));
@@ -519,7 +519,7 @@ describe('frint-compat › components › mapToProps', function () {
 
             return acc;
           }, {
-            name: app.getOption('name'),
+            name: app.getName(),
             total: 0
           });
       }

--- a/packages/frint-react-server/src/renderToString.spec.js
+++ b/packages/frint-react-server/src/renderToString.spec.js
@@ -50,7 +50,7 @@ describe('frint-react-server › renderToString', function () {
 
     const ObservedTestComponent = observe(function (app) {
       return Observable.of({
-        name: app.getOption('name'),
+        name: app.getName(),
       });
     })(TestComponent);
 

--- a/packages/frint-react/src/components/observe.spec.js
+++ b/packages/frint-react/src/components/observe.spec.js
@@ -66,7 +66,7 @@ describe('frint-react › components › observe', function () {
 
     const ObservedComponent = observe(function (app) {
       return Observable
-        .of(app.getName())
+        .of(app.getOption('name'))
         .map(name => ({ name }));
     })(Component);
 
@@ -116,7 +116,7 @@ describe('frint-react › components › observe', function () {
 
     const ObservedComponent = observe(function (app) {
       return Observable
-        .of(app.getName())
+        .of(app.getOption('name'))
         .map(name => ({ name }));
     })(Component);
 

--- a/packages/frint-react/src/components/observe.spec.js
+++ b/packages/frint-react/src/components/observe.spec.js
@@ -66,7 +66,7 @@ describe('frint-react › components › observe', function () {
 
     const ObservedComponent = observe(function (app) {
       return Observable
-        .of(app.getOption('name'))
+        .of(app.getName())
         .map(name => ({ name }));
     })(Component);
 
@@ -116,7 +116,7 @@ describe('frint-react › components › observe', function () {
 
     const ObservedComponent = observe(function (app) {
       return Observable
-        .of(app.getOption('name'))
+        .of(app.getName())
         .map(name => ({ name }));
     })(Component);
 

--- a/packages/frint-react/src/components/observe.spec.js
+++ b/packages/frint-react/src/components/observe.spec.js
@@ -86,8 +86,7 @@ describe('frint-react › components › observe', function () {
       afterMount() {},
       beforeUnmount() {},
       getName() {
-        const options = { name: 'FakeApp' };
-        return options.name;
+        return 'FakeApp';
       }
     };
 

--- a/packages/frint-react/src/components/observe.spec.js
+++ b/packages/frint-react/src/components/observe.spec.js
@@ -66,7 +66,7 @@ describe('frint-react › components › observe', function () {
 
     const ObservedComponent = observe(function (app) {
       return Observable
-        .of(app.getOption('name'))
+        .of(app.getName())
         .map(name => ({ name }));
     })(Component);
 
@@ -85,9 +85,9 @@ describe('frint-react › components › observe', function () {
       beforeMount() {},
       afterMount() {},
       beforeUnmount() {},
-      getOption(key) {
+      getName() {
         const options = { name: 'FakeApp' };
-        return options[key];
+        return options.name;
       }
     };
 
@@ -116,12 +116,12 @@ describe('frint-react › components › observe', function () {
 
     const ObservedComponent = observe(function (app) {
       return Observable
-        .of(app.getOption('name'))
+        .of(app.getName())
         .map(name => ({ name }));
     })(Component);
 
     const fakeApp = {
-      getOption() {
+      getName() {
         return 'ShallowApp';
       }
     };

--- a/packages/frint/README.md
+++ b/packages/frint/README.md
@@ -236,7 +236,7 @@ const RootApp = createApp({
     {
       name: 'theNameOfTheApp',
       useFactory: function ({ app }) {
-        return app.getOption('name');
+        return app.app.getName();
       },
       deps: ['app'],
       cascade: true,
@@ -303,6 +303,8 @@ The `App` instance
 #### Example
 
 `app.getOption('name')` would give you `MyAppName` string.
+
+or better `app.getName()` Since name in options is a required key.
 
 ### app.getRootApp
 

--- a/packages/frint/README.md
+++ b/packages/frint/README.md
@@ -304,7 +304,13 @@ The `App` instance
 
 `app.getOption('name')` would give you `MyAppName` string.
 
-or better `app.getName()` Since name in options is a required key.
+### app.getName
+
+> app.getName()
+
+#### Returns
+
+`String`: The App's name.
 
 ### app.getRootApp
 

--- a/packages/frint/src/App.js
+++ b/packages/frint/src/App.js
@@ -177,6 +177,10 @@ App.prototype.getOption = function getOption(key) {
   return _.get(this.options, key);
 };
 
+App.prototype.getName = function getName() {
+  return this.getOption('name');
+};
+
 App.prototype.getProviders = function getProviders() {
   return this.options.providers;
 };

--- a/packages/frint/src/App.spec.js
+++ b/packages/frint/src/App.spec.js
@@ -21,7 +21,7 @@ describe('frint  › App', function () {
       name: 'MyApp',
     });
 
-    expect(app.getOption('name')).to.equal('MyApp');
+    expect(app.getName()).to.equal('MyApp');
   });
 
   it('gets parent and root app', function () {
@@ -39,8 +39,8 @@ describe('frint  › App', function () {
       parentApp: childApp,
     });
 
-    expect(rootApp.getOption('name')).to.equal('RootApp');
-    expect(childApp.getOption('name')).to.equal('ChildApp');
+    expect(rootApp.getName()).to.equal('RootApp');
+    expect(childApp.getName()).to.equal('ChildApp');
     expect(rootApp.getParentApps()).to.deep.equal([]);
 
     expect(childApp.getParentApp()).to.deep.equal(rootApp);
@@ -263,7 +263,7 @@ describe('frint  › App', function () {
       }
     });
 
-    expect(app.getOption('name')).to.equal('MyApp');
+    expect(app.getName()).to.equal('MyApp');
     expect(called).to.equal(true);
   });
 
@@ -278,7 +278,7 @@ describe('frint  › App', function () {
     });
     app.beforeDestroy();
 
-    expect(app.getOption('name')).to.equal('MyApp');
+    expect(app.getName()).to.equal('MyApp');
     expect(called).to.equal(true);
   });
 
@@ -373,7 +373,7 @@ describe('frint  › App', function () {
 
     root.getAppOnceAvailable$('App1')
       .subscribe(function (app) {
-        expect(app.getOption('name')).to.equal('App1');
+        expect(app.getName()).to.equal('App1');
 
         done();
       });
@@ -390,7 +390,7 @@ describe('frint  › App', function () {
 
     root.getAppOnceAvailable$('App1')
       .subscribe(function (app) {
-        expect(app.getOption('name')).to.equal('App1');
+        expect(app.getName()).to.equal('App1');
 
         done();
       });

--- a/packages/frint/src/createApp.spec.js
+++ b/packages/frint/src/createApp.spec.js
@@ -20,6 +20,6 @@ describe('frint › createApp', function () {
     });
 
     expect(app).to.be.instanceOf(App);
-    expect(app.getOption('name')).to.equal('MyAppNameFromInstance');
+    expect(app.getName()).to.equal('MyAppNameFromInstance');
   });
 });

--- a/site/content/docs/migration/v1.md
+++ b/site/content/docs/migration/v1.md
@@ -187,7 +187,7 @@ import { createApp, createService } from 'frint';
 
 const FooService = createService({
   getAppName() {
-    return this.app.getOption('name');
+    return this.app.getName();
   }
 });
 
@@ -214,7 +214,7 @@ class FooService {
   }
 
   getAppName() {
-    return this.app.getOption('name');
+    return this.app.getName();
   }
 }
 
@@ -243,7 +243,7 @@ import { createApp, createFactory } from 'frint';
 
 const BarFactory = createFactory({
   getAppName() {
-    return this.app.getOption('name');
+    return this.app.getName();
   }
 });
 
@@ -270,7 +270,7 @@ class BarFactory {
   }
 
   getAppName() {
-    return this.app.getOption('name');
+    return this.app.getName();
   }
 }
 
@@ -368,7 +368,7 @@ export default mapToProps({
   },
   app(app) {
     return {
-      appName: app.getOption('name')
+      appName: app.getName()
     }
   }),
   shared(sharedState) => ({
@@ -426,7 +426,7 @@ export default observe(function (app) {
     }, app.get('store'))
 
     // app
-    .set('appName', app.getOption('name'))
+    .set('appName', app.getName())
 
     // shared state
     .set(

--- a/site/content/guides/apps.md
+++ b/site/content/guides/apps.md
@@ -48,7 +48,7 @@ Now you can instantiate it:
 
 ```js
 const app = new App();
-const name = app.getOption('name');
+const name = app.getName();
 console.log(name); // `MyAppName`
 ```
 
@@ -97,7 +97,7 @@ To access your App instance:
 ```js
 window.app.getAppOnceAvailable$('MyApp')
   .subscribe(function (app) {
-    const name = app.getOption('name');
+    const name = app.getName();
     console.log(name); // `MyApp`
   });
 ```

--- a/site/content/guides/higher-order-components.md
+++ b/site/content/guides/higher-order-components.md
@@ -95,7 +95,7 @@ function MyComponent(props) {
 export default observe(function (app) {
   // `app` is our App's instance
   const props = {
-    name: app.getOption('name') // `MyAppNameHere`
+    name: app.getName() // `MyAppNameHere`
   };
 
   // this function must always return an Observable of props


### PR DESCRIPTION
instead of getOption('name') use the method getName.

issue #184 