### PR TITLE
frint-router-react › Switch component: unit tests and a little refactoring

### DIFF
--- a/packages/frint-router-react/src/Route.js
+++ b/packages/frint-router-react/src/Route.js
@@ -104,7 +104,7 @@ export default class Route extends React.Component {
 
   render() {
     const ComponentToRender = this.state.component;
-    const matched = this.props.computedMatch || this.state.matched;
+    const matched = this.props.computedMatch || this.state.matched || null;
 
     return ComponentToRender !== null && matched !== null
       ? <ComponentToRender match={matched} />

--- a/packages/frint-router-react/src/Switch.js
+++ b/packages/frint-router-react/src/Switch.js
@@ -19,11 +19,11 @@ export default class Switch extends React.Component {
       history: null,
     };
 
-    this.subscription = null;
+    this._routerSubscription = null;
   }
 
   componentWillMount() {
-    this.subscription = this.context.app
+    this._routerSubscription = this.context.app
       .get('router')
       .getHistory$()
       .subscribe((history) => {
@@ -34,8 +34,8 @@ export default class Switch extends React.Component {
   }
 
   componentWillUnmount() {
-    if (this.subscription) {
-      this.subscription.unsubscribe();
+    if (this._routerSubscription) {
+      this._routerSubscription.unsubscribe();
     }
   }
 
@@ -47,26 +47,17 @@ export default class Switch extends React.Component {
         return;
       }
 
-      if (!React.isValidElement(element)) {
-        return;
-      }
-
       const { path, exact } = element.props;
 
-      if (!path) {
-        child = React.cloneElement(element);
-
-        return;
-      }
-
-      const route = this.context.app
+      // if Route has no path (it's default) then getMatch will return match with whatever URL
+      const match = this.context.app
         .get('router')
         .getMatch(path, this.state.history, { exact });
 
-      if (route !== null) {
+      if (match !== null) {
         child = React.cloneElement(element, {
           ...element.props,
-          computedRoute: route,
+          computedMatch: match,
         });
       }
     });

--- a/packages/frint-router-react/src/Switch.js
+++ b/packages/frint-router-react/src/Switch.js
@@ -47,6 +47,10 @@ export default class Switch extends React.Component {
         return;
       }
 
+      if (!React.isValidElement(element)) {
+        return;
+      }
+
       const { path, exact } = element.props;
 
       // if Route has no path (it's default) then getMatch will return match with whatever URL

--- a/packages/frint-router-react/src/Switch.spec.js
+++ b/packages/frint-router-react/src/Switch.spec.js
@@ -29,7 +29,7 @@ function createContext() {
   };
 }
 
-describe('frint-route-react › Switch', function () {
+describe('frint-router-react › Switch', function () {
   it('switches routes according to router and passes computedMatch', function () {
     const HomeComponent = () => <header>HomeComponent</header>;
     const AboutComponent = () => <article>AboutComponent</article>;
@@ -285,7 +285,7 @@ describe('frint-route-react › Switch', function () {
     });
   });
 
-  it('doesn\'t crash when not Reacts elements are passed as children', function () {
+  it('doesn\'t crash when not React elements are passed as children', function () {
     const DefaultComponent = () => <h2>DefaultComponent</h2>;
 
     const context = createContext();

--- a/packages/frint-router-react/src/Switch.spec.js
+++ b/packages/frint-router-react/src/Switch.spec.js
@@ -1,0 +1,287 @@
+/* eslint-disable import/no-extraneous-dependencies, func-names, no-unused-expressions */
+/* global describe, it */
+import { expect } from 'chai';
+import React from 'react';
+import PropTypes from 'prop-types';
+import { shallow, mount } from 'enzyme';
+import { createApp } from 'frint';
+import { MemoryRouterService } from 'frint-router';
+
+import Route from './Route';
+import Switch from './Switch';
+
+function createContext() {
+  const App = createApp({
+    name: 'TestRouterApp',
+    providers: [
+      {
+        name: 'router',
+        useFactory: function () {
+          return new MemoryRouterService();
+        },
+        cascade: true,
+      },
+    ],
+  });
+
+  return {
+    app: new App()
+  };
+}
+
+describe('frint-route-react › Switch', function () {
+  it('switches routes according to router and passes computedMatch', function () {
+    const HomeComponent = () => <header>HomeComponent</header>;
+    const AboutComponent = () => <article>AboutComponent</article>;
+    const NotFound = () => <div>Not found</div>;
+
+    const context = createContext();
+    const router = context.app.get('router');
+
+    const wrapper = shallow(
+      <Switch>
+        <Route component={HomeComponent} exact path="/"/>
+        <Route component={AboutComponent} path="/about" />
+        <Route component={NotFound} />
+      </Switch>,
+      { context }
+    );
+
+
+    it('renders Route when it\'s path matches exactly', function () {
+      router.push('/');
+
+      expect(wrapper.type()).to.equal(Route);
+
+      expect(wrapper.props()).to.deep.equal({
+        computedMatch: { url: '/', isExact: true, params: {} },
+        component: HomeComponent,
+        exact: true,
+        path: '/'
+      });
+    });
+
+    it('renders Route when it\'s path matches inexactly, skipping first one which requires exact match', function () {
+      router.push('/about/our-sport-team');
+
+      expect(wrapper.props()).to.deep.equal({
+        computedMatch: { url: '/about', isExact: false, params: {} },
+        component: AboutComponent,
+        path: '/about'
+      });
+    });
+
+    it('renders default Route when nothing matches and doesn\'t pass computedMatch to it', function () {
+      router.push('/not-the-page-youre-looking-for');
+
+      expect(wrapper.props()).to.deep.equal({
+        component: NotFound,
+        computedMatch: { url: '/not-the-page-youre-looking-for', isExact: false, params: {} }
+      });
+    });
+  });
+
+  it('renders only first match', function () {
+    const FirstComponent = () => <h1>FirstComponent</h1>;
+    const SecondComponent = () => <h2>SecondComponent</h2>;
+
+    const context = createContext();
+    const router = context.app.get('router');
+
+    const wrapper = shallow(
+      <Switch>
+        <Route component={FirstComponent} path="/about" />
+        <Route component={SecondComponent} path="/about" />
+      </Switch>,
+      { context }
+    );
+
+    router.push('/about');
+
+    expect(wrapper.type()).to.equal(Route);
+
+    expect(wrapper.props()).to.deep.equal({
+      computedMatch: { url: '/about', isExact: true, params: {} },
+      component: FirstComponent,
+      path: '/about'
+    });
+  });
+
+  it('renders only first match, also if it\'s default', function () {
+    const DefaultComponent = () => <h1>DefaultComponent</h1>;
+    const SecondComponent = () => <h2>SecondComponent</h2>;
+
+    const context = createContext();
+    const router = context.app.get('router');
+
+    const wrapper = shallow(
+      <Switch>
+        <Route component={DefaultComponent} />
+        <Route component={SecondComponent} path="/services" />
+      </Switch>,
+      { context }
+    );
+
+    router.push('/services');
+
+    expect(wrapper.type()).to.equal(Route);
+    expect(wrapper.props()).to.deep.equal({
+      component: DefaultComponent,
+      computedMatch: { url: '/services', isExact: false, params: {} }
+    });
+  });
+
+  it('renders nothing if there\'s no match', function () {
+    const ServicesComponent = () => <h2>ServicesComponent</h2>;
+
+    const context = createContext();
+    const router = context.app.get('router');
+
+    const wrapper = shallow(
+      <Switch>
+        <Route component={ServicesComponent} path="/services" />
+      </Switch>,
+      { context }
+    );
+
+    router.push('/about');
+
+    expect(wrapper.type()).to.equal(null);
+  });
+
+  it('renders nothing if there\'s no match', function () {
+    const ServicesComponent = () => <h2>ServicesComponent</h2>;
+
+    const context = createContext();
+    const router = context.app.get('router');
+
+    const wrapper = shallow(
+      <Switch>
+        <Route component={ServicesComponent} path="/services" />
+      </Switch>,
+      { context }
+    );
+
+    router.push('/about');
+
+    expect(wrapper.type()).to.equal(null);
+  });
+
+  it('unsubscribes from router on unmount', function () {
+    let subscribeCount = 0;
+    let unsubscribeCount = 0;
+
+    const subscription = {
+      unsubscribe() {
+        unsubscribeCount += 1;
+      }
+    };
+
+    const router = {
+      getHistory$() {
+        return {
+          subscribe() {
+            subscribeCount += 1;
+            return subscription;
+          }
+        };
+      }
+    };
+
+    const context = {
+      app: {
+        // eslint-disable-next-line consistent-return
+        get(key) {
+          if (key === 'router') {
+            return router;
+          }
+        }
+      }
+    };
+
+    const wrapper = shallow(
+      <Switch />,
+      { context }
+    );
+
+    expect(subscribeCount).to.equal(1);
+    expect(unsubscribeCount).to.equal(0);
+
+    wrapper.unmount();
+    expect(subscribeCount).to.equal(1);
+    expect(unsubscribeCount).to.equal(1);
+  });
+
+  describe('switches routes correctly when child Routes are changing', function () {
+    let beforeDestroyCallCount = 0;
+
+    const HomeApp = createApp({
+      name: 'HomeApp',
+      providers: [
+        {
+          name: 'component',
+          useValue: () => <article>HomeApp</article>,
+        },
+      ],
+      beforeDestroy: () => {
+        beforeDestroyCallCount += 1;
+      }
+    });
+
+    const WrapperComponent = ({ routeSet }) => {
+      const changingRoutes = [];
+
+      if (routeSet === 1) {
+        changingRoutes.push(
+          <Route component={() => <header>HomeComponent</header>} exact key="1h" path="/home" />,
+          <Route component={() => <article>ServicesComponent</article>} key="1s" path="/services" />,
+        );
+      } else if (routeSet === 2) {
+        changingRoutes.push(
+          <Route app={HomeApp} exact key="2h" path="/home" />
+        );
+      }
+
+      return (
+        <Switch>
+          {changingRoutes}
+          <Route component={() => <div>Not found</div>} key="0n" />
+        </Switch>
+      );
+    };
+
+    WrapperComponent.propTypes = {
+      routeSet: PropTypes.number
+    };
+
+    const context = createContext();
+    const router = context.app.get('router');
+
+    const wrapper = mount(
+      <WrapperComponent routeSet={1} />,
+      { context, childContextTypes: { app: PropTypes.object } }
+    );
+
+    it('renders matching Route and component from the first set', function () {
+      router.push('/services');
+      expect(wrapper.html()).to.equal('<article>ServicesComponent</article>');
+    });
+
+    it('falls back to default when matching Route disappears', function () {
+      wrapper.setProps({ routeSet: 2 });
+      expect(wrapper.html()).to.equal('<div>Not found</div>');
+    });
+
+    it('renders matching HomeApp when URL matches', function () {
+      router.push("/home");
+      expect(wrapper.html()).to.equal('<article>HomeApp</article>');
+      expect(beforeDestroyCallCount).to.equal(0);
+    });
+
+    it('renders another component matching the same route, destorying previous app', function () {
+      wrapper.setProps({ routeSet: 1 });
+      expect(beforeDestroyCallCount).to.equal(1);
+      expect(wrapper.html()).to.equal('<header>HomeComponent</header>');
+    });
+  });
+});

--- a/packages/frint-router-react/src/Switch.spec.js
+++ b/packages/frint-router-react/src/Switch.spec.js
@@ -284,4 +284,25 @@ describe('frint-route-react › Switch', function () {
       expect(wrapper.html()).to.equal('<header>HomeComponent</header>');
     });
   });
+
+  it('doesn\'t crash when not Reacts elements are passed as children', function () {
+    const DefaultComponent = () => <h2>DefaultComponent</h2>;
+
+    const context = createContext();
+
+    const wrapper = shallow(
+      <Switch>
+        {0}
+        {'string'}
+        <Route component={DefaultComponent} />
+      </Switch>,
+      { context }
+    );
+
+    expect(wrapper.type()).to.equal(Route);
+    expect(wrapper.props()).to.deep.equal({
+      component: DefaultComponent,
+      computedMatch: { url: '/', isExact: false, params: {} }
+    });
+  });
 });


### PR DESCRIPTION
Some changes in functionality:
- added passing of computedMath to default Route (otherwise it didn't render because there were no match)
- removed React.isValidElement check. I just couldn't come up with unit test for it. if we want to make it fool-proof, we can test it with crazy children like {' '} or () => ... or {15}, so that it would at least issue a warning that it's not a way to go.