### PR TITLE
frint-router: check result of RegExp.exec using Array.isArray

### DIFF
--- a/packages/frint-router/src/matchFromHistory.js
+++ b/packages/frint-router/src/matchFromHistory.js
@@ -17,7 +17,7 @@ export default function matchFromHistory(pattern, history, options = {}) {
 
   const matched = re.exec(history.location.pathname);
 
-  if (!matched) {
+  if (!Array.isArray(matched)) {
     return null;
   }
 


### PR DESCRIPTION
Following Jean's comment: https://github.com/Travix-International/frint/pull/244#discussion_r130294194