### PR TITLE
Extend the prototype of Model at definition time

### DIFF
--- a/packages/frint-model/src/createModel.js
+++ b/packages/frint-model/src/createModel.js
@@ -13,7 +13,7 @@ export default function createModel(extend = {}) {
       }
     }
   }
-  
+
   _.merge(Model.prototype, extend);
 
   return Model;

--- a/packages/frint-model/src/createModel.js
+++ b/packages/frint-model/src/createModel.js
@@ -8,13 +8,13 @@ export default function createModel(extend = {}) {
     constructor(...args) {
       super(...args);
 
-      _.merge(this, extend);
-
       if (typeof this.initialize === 'function') {
         this.initialize(...args);
       }
     }
   }
+  
+  _.merge(Model.prototype, extend);
 
   return Model;
 }


### PR DESCRIPTION
Instead of extending the model instance each time, we should extend the Model class definition a single time. This has some benefits:

- Allows us to test model method definitions without instantiating them:

```js
// Before
const myModel = new MyModel(attrs);
expect(myModel.someMethod()).to.equal('something');

// After
expect(MyModel.prototype.someMethod.call(stub)).to.equal('something');
```

- An edge case, but still: It prevents a developer from having model instances with different behaviours (which would happen if the extend object would be modified from outside)

```js
const attrs = {
  myMethod() {
    return 'something';
  }
}

const MyModel = createModel(attrs);

const myModel = new MyModel({});
myModel.myMethod() // -> 'something'

attrs.myMethod = function() {
  return 'anotherThing';
}

const otherModel = new MyModel({});
otherModel.myMethod() // -> 'anotherThing';
```

- It's a micro performance improvement.