### PR TITLE
Apply Webpack’s `externals` more accurately to reduce dist sizes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ after_success:
   - 'npm run cover'
   - './node_modules/.bin/istanbul-combine -d coverage -p summary -r lcov -r html packages/frint*/coverage/coverage*.json'
   - 'cat ./coverage/lcov.info | ./node_modules/.bin/coveralls'
-  - 'npm run dist'
-  - 'make list-dists'
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ after_success:
   - 'npm run cover'
   - './node_modules/.bin/istanbul-combine -d coverage -p summary -r lcov -r html packages/frint*/coverage/coverage*.json'
   - 'cat ./coverage/lcov.info | ./node_modules/.bin/coveralls'
+  - 'npm run dist'
+  - 'make list-dists'
 
 notifications:
   email: false

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,9 @@ list-packages:
 list-updated:
 	./node_modules/.bin/lerna updated
 
+list-dists:
+	ls -alh ./packages/frint*/dist/*.js | awk '{print $$5 "\t" $$9 }'
+
 ##
 # Site
 site-fetch-contributors:

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,15 @@ list-updated:
 	./node_modules/.bin/lerna updated
 
 list-dists:
-	ls -alh ./packages/frint*/dist/*.js | awk '{print $$5 "\t" $$9 }'
+	@echo "original \\t gzipped \\t file"
+	@echo "--- \\t\\t --- \\t\\t ---"
+	@ls -alh ./packages/frint*/dist/*.js | grep '.min.js' | awk '{print $$9 }' | while read LINE; do\
+		SIZE="$$(cat $${LINE} | wc -c | bc)";\
+		SIZE_IN_KB=$$(echo "scale=1; $${SIZE} / 1024" | bc);\
+		GZIPPED_SIZE="$$(gzip -c $${LINE} | wc -c | bc)";\
+		GZIPPED_SIZE_IN_KB=$$(echo "scale=1; $${GZIPPED_SIZE} / 1024" | bc);\
+		echo "$${SIZE_IN_KB}K \\t\\t $${GZIPPED_SIZE_IN_KB}K \\t\\t $${LINE}";\
+	done
 
 ##
 # Site

--- a/packages/frint-compat/webpack.config.js
+++ b/packages/frint-compat/webpack.config.js
@@ -29,6 +29,7 @@ module.exports = {
     'frint-react': 'FrintReact',
     'frint-store': 'FrintStore',
     'lodash': '_',
+    'prop-types': 'PropTypes',
     'react': 'React',
     'react-dom': 'ReactDOM',
     'rxjs': 'Rx',

--- a/packages/frint-model/webpack.config.js
+++ b/packages/frint-model/webpack.config.js
@@ -25,6 +25,7 @@ module.exports = {
   },
   externals: {
     'lodash': '_',
+    'rxjs': 'Rx',
   },
   target: 'web',
   plugins: plugins,

--- a/packages/frint-react/webpack.config.js
+++ b/packages/frint-react/webpack.config.js
@@ -26,6 +26,7 @@ module.exports = {
   externals: {
     'frint': 'Frint',
     'lodash': '_',
+    'prop-types': 'PropTypes',
     'react': 'React',
     'react-dom': 'ReactDOM',
     'rxjs': 'Rx',

--- a/packages/frint-router-react/webpack.config.js
+++ b/packages/frint-router-react/webpack.config.js
@@ -28,6 +28,7 @@ module.exports = {
     'react': 'React',
     'rxjs': 'Rx',
     'prop-types': 'PropTypes',
+    'frint-react': 'FrintReact',
     'frint-router': 'FrintRouter',
   },
   target: 'web',


### PR DESCRIPTION
## What's done

We were missing some `externals` in our Webpack configs, which resulted in bigger dist sizes. This has now been fixed.

Those using FrintJS via CDN can now benefit from reduced size.

## New

Added a new `make list-dists` command.

## Comparison

### Before

```
$ make list-dists | grep '.min.js'
25K	./packages/frint-compat/dist/frint-compat.min.js
202K	./packages/frint-model/dist/frint-model.min.js
22K	./packages/frint-react/dist/frint-react.min.js
239K	./packages/frint-router-react/dist/frint-router-react.min.js
26K	./packages/frint-router/dist/frint-router.min.js
6.5K	./packages/frint-store/dist/frint-store.min.js
11K	./packages/frint/dist/frint.min.js
```

### After

```
$ make list-dists | grep '.min.js'
15K	./packages/frint-compat/dist/frint-compat.min.js
2.6K	./packages/frint-model/dist/frint-model.min.js
12K	./packages/frint-react/dist/frint-react.min.js
8.7K	./packages/frint-router-react/dist/frint-router-react.min.js
26K	./packages/frint-router/dist/frint-router.min.js
6.5K	./packages/frint-store/dist/frint-store.min.js
11K	./packages/frint/dist/frint.min.js
```

## Gzipped size

```
$ make list-dists
original 	 gzipped 	 file
--- 		 --- 		 ---
15.2K 		 3.4K 		 ./packages/frint-compat/dist/frint-compat.min.js
2.6K 		 1.0K 		 ./packages/frint-model/dist/frint-model.min.js
11.8K 		 2.8K 		 ./packages/frint-react/dist/frint-react.min.js
8.6K 		 2.0K 		 ./packages/frint-router-react/dist/frint-router-react.min.js
25.7K 		 7.7K 		 ./packages/frint-router/dist/frint-router.min.js
6.5K 		 2.2K 		 ./packages/frint-store/dist/frint-store.min.js
11.1K 		 2.9K 		 ./packages/frint/dist/frint.min.js
```