### PR TITLE
Remove redundant square brackets from Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [frintjs-conduct@googlegroups.com]
+reported by contacting the project team at frintjs-conduct@googlegroups.com
 All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident.
 Further details of specific enforcement policies may be posted separately.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 For documentation, visit [https://frint.js.org](https://frint.js.org).
 
 This project adheres to the Contributor Covenant code of conduct. By participating, you are expected to uphold this code.
-Please report unacceptable behavior to [frintjs-conduct@googlegroups.com].
+Please report unacceptable behavior to frintjs-conduct@googlegroups.com.
 
 ## Quick start
 


### PR DESCRIPTION
Please @fahad19 let me know if now it is ok :) and thanks for your remarks