### PR TITLE
Make `isObservable` more generic

### DIFF
--- a/packages/frint-react/src/isObservable.js
+++ b/packages/frint-react/src/isObservable.js
@@ -7,12 +7,7 @@
  * @return boolean
  */
 export default function isObservable(obj) {
-  if (
-    obj &&
-    typeof obj.subscribe === 'function' &&
-    typeof obj.map === 'function' &&
-    typeof obj.filter === 'function'
-  ) {
+  if (obj && typeof obj.subscribe === 'function') {
     return true;
   }
 


### PR DESCRIPTION
While this works great for us for now, this also means anyone else who is importing RxJS like this import { Observable } from 'rxjs/Observable'; would face a problem right away

Closes #274 