### PR TITLE
frint-react: Declare app in context of Region

### DIFF
--- a/packages/frint-react/src/components/Region.js
+++ b/packages/frint-react/src/components/Region.js
@@ -15,7 +15,7 @@ export default class Region extends React.Component {
 
   static contextTypes = {
     app: PropTypes.object,
-  }
+  };
 
   constructor(...args) {
     super(...args);

--- a/packages/frint-react/src/components/Region.js
+++ b/packages/frint-react/src/components/Region.js
@@ -13,6 +13,10 @@ export default class Region extends React.Component {
     data: PropTypes.any,
   };
 
+  static contextTypes = {
+    app: PropTypes.object,
+  }
+
   constructor(...args) {
     super(...args);
 


### PR DESCRIPTION
Declaring the context types in the Region will allow to access the parent app that is being passed by the `observe` hoc.

Fixes #256 