### PR TITLE
Remove end of line setting from .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,6 @@ root = true
 charset = utf-8
 indent_style = space
 indent_size = 2
-end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 


### PR DESCRIPTION
Closes https://github.com/Travix-International/frint/issues/285

`end_of_line` should not be specified, as it differs from platform to platform. A common approach is to let VCS decide this instead.

A potential future solution for `end_of_line = native` is discussed here:
https://github.com/editorconfig/editorconfig/issues/226