### PR TITLE
Ignore package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ yarn.lock
 lib
 .changelog/
 _site
+package-lock.json
 
 # Ignore vim temporary files
 *~


### PR DESCRIPTION
Since package lock is not intended to be version controlled for Frint, prevent it from constantly popping up in the working tree.

We may want to wait with this PR until node 8 / npm 5 go into LTS.

Ignoring the lock files for examples is not going to be a problem since examples are planned to be used in a way where lock files don't make sense. @fahad19 can elaborate on it further if needed.