### PR TITLE
frint-router-react: inline rendering via Route component

### DIFF
--- a/packages/frint-router-react/README.md
+++ b/packages/frint-router-react/README.md
@@ -309,6 +309,7 @@ This package is a close implementation of the APIs introduced by the awesome [`r
   * Example (with params): `/about/:user`
 1. `exact` (`Boolean`): Match the `path` exactly (with no suffix in the path)
 1. `component` (`Component`): The React component to render
+1, `render` (`Function`): For rendering inline via wrapped stateless components
 1. `app` (`App`): Frint App that you want to render
 
 ## Link

--- a/packages/frint-router-react/src/Route.js
+++ b/packages/frint-router-react/src/Route.js
@@ -14,6 +14,7 @@ export default class Route extends React.Component {
     exact: PropTypes.bool,
     computedMatch: PropTypes.object,
     component: PropTypes.func,
+    render: PropTypes.func,
     app: PropTypes.func,
   };
 
@@ -106,8 +107,18 @@ export default class Route extends React.Component {
     const ComponentToRender = this.state.component;
     const matched = this.props.computedMatch || this.state.matched || null;
 
-    return ComponentToRender !== null && matched !== null
-      ? <ComponentToRender match={matched} />
-      : null;
+    if (!matched) {
+      return null;
+    }
+
+    if (ComponentToRender) {
+      return <ComponentToRender match={matched} />;
+    }
+
+    if (this.props.render) {
+      return this.props.render({ match: matched });
+    }
+
+    return null;
   }
 }

--- a/packages/frint-router-react/src/Route.spec.js
+++ b/packages/frint-router-react/src/Route.spec.js
@@ -80,6 +80,35 @@ describe('frint-route-react › Route', function () {
     expect(wrapper.type()).to.equal(Component);
   });
 
+  it('renders stateless component, when route is matched not exactly', function () {
+    const context = createContext();
+    const wrapper = shallow(
+      <Route
+        path="/about"
+        render={function ({ match }) {
+          return (
+            <div>
+              <div className="url">{match.url}</div>
+            </div>
+          );
+        }}
+      />,
+      { context }
+    );
+
+    context.app.get('router').push('/');
+    expect(wrapper.type()).to.be.null;
+
+    context.app.get('router').push('/about');
+    expect(wrapper.find('.url').text()).to.equal('/about');
+
+    context.app.get('router').push('/service');
+    expect(wrapper.type()).to.be.null;
+
+    context.app.get('router').push('/about/contact');
+    expect(wrapper.find('.url').text()).to.equal('/about');
+  });
+
   it('renders component when exact prop passed and route is matched exactly', function () {
     const Component = () => <div>Matched</div>;
 


### PR DESCRIPTION
Closes #302 

**Note**: No breaking changes.

## What's done

The `<Route />` component now supports inline rendering via `render` prop:

```js
<Route
  path="/about"
  render={() => <p>Hi</p>}
/>
```

Doing so would allow passing extra props to the components, without risking any unmounting of the rendered components:

```js
import Foo from './Foo';
const fooProps = {};

<Route
  path="/foo"
  render={(routeProps) => (
    <Foo 
      customProps={fooProps} 
      {...routeProps} 
    />
  )}
/>
```
