### PR TITLE
frint-model: Deprecated

### DIFF
--- a/.alexrc
+++ b/.alexrc
@@ -7,6 +7,7 @@
     "dead",
     "dumb",
     "executes",
+    "execution",
     "failed",
     "hooks",
     "jacktheripper"

--- a/README.md
+++ b/README.md
@@ -42,25 +42,63 @@ Find more examples [here](https://github.com/Travix-International/frint/tree/mas
 
 The framework is a collection of these packages, which can be composed together on demand:
 
-* [frint](./packages/frint): The base of the framework.
-* [frint-store](./packages/frint-store): For creating reactive reducer-based stores for state management.
-* [frint-model](./packages/frint-model): For creating models for data structures.
-* [frint-data](./packages/frint-data): Reactive data modelling.
-* [frint-react](./packages/frint-react): For creating React-compatible reactive components.
-* [frint-react-server](./packages/frint-react-server): Server-side rendering for Apps.
-* [frint-router](./packages/frint-router): Router services for single page applications (SPA).
-* [frint-router-react](./packages/frint-router-react): React components for building SPAs.
-* [frint-cli](./packages/frint-cli): CLI runner.
-* [frint-compat](./packages/frint-compat): Backwards compatibility support for `v0.x` users.
+| Package                    | Status                                                                 | Description |
+|----------------------------|------------------------------------------------------------------------|-------------|
+| [frint]                    | [![frint-status]][frint-package]                                       | Base for creating Apps |
+| [frint-store]              | [![frint-store-status]][frint-store-package]                           | State management with reactive stores |
+| [frint-data]               | [![frint-data-status]][frint-data-package]                             | Reactive data modelling |
+| [frint-react]              | [![frint-react-status]][frint-react-package]                           | React.js integration |
+| [frint-react-server]       | [![frint-react-server-status]][frint-react-server-package]             | Server-rendering of Apps |
+| [frint-router]             | [![frint-router-status]][frint-router-package]                         | Router services for building Single Page Applications |
+| [frint-router-react]       | [![frint-router-react-status]][frint-router-react-package]             | React components for building SPAs |
+| [frint-cli]                | [![frint-cli-status]][frint-cli-package]                               | CLI runner |
+| [frint-compat]             | [![frint-compat-status]][frint-compat-package]                         | Backwards compatibility for older versions |
+| [frint-model]              | [![frint-model-status]][frint-model-package]                           | Use `frint-data` instead |
+| [frint-component-utils]    | [![frint-component-utils-status]][frint-component-utils-package]       | Utils for reactive Components |
+| [frint-component-handlers] | [![frint-component-handlers-status]][frint-component-handlers-package] | Handlers for integrating with other rendering libraries |
+| [frint-test-utils]         | [![frint-test-utils-status]][frint-test-utils-package]                 | Internally used test utilities |
 
-For library developers:
+[frint]: https://frint.js.org/docs/packages/frint
+[frint-store]: https://frint.js.org/docs/packages/frint-store
+[frint-model]: https://frint.js.org/docs/packages/frint-model
+[frint-data]: https://frint.js.org/docs/packages/frint-data
+[frint-react]: https://frint.js.org/docs/packages/frint-react
+[frint-react-server]: https://frint.js.org/docs/packages/frint-react-server
+[frint-router]: https://frint.js.org/docs/packages/frint-router
+[frint-router-react]: https://frint.js.org/docs/packages/frint-router-react
+[frint-cli]: https://frint.js.org/docs/packages/frint-cli
+[frint-compat]: https://frint.js.org/docs/packages/frint-compat
+[frint-component-utils]: https://frint.js.org/docs/packages/frint-component-utils
+[frint-component-handlers]: https://frint.js.org/docs/packages/frint-component-handlers
+[frint-test-utils]: https://frint.js.org/docs/packages/frint-test-utils
 
-* [frint-component-utils](./packages/frint-component-utils): Utils for reactive components.
-* [frint-component-handlers](./packages/frint-component-handlers): Handlers for integrating other rendering libraries with FrintJS.
+[frint-status]: https://img.shields.io/npm/v/frint.svg
+[frint-store-status]: https://img.shields.io/npm/v/frint-store.svg
+[frint-model-status]: https://img.shields.io/badge/status-deprecated-orange.svg
+[frint-data-status]: https://img.shields.io/npm/v/frint-data.svg
+[frint-react-status]: https://img.shields.io/npm/v/frint-react.svg
+[frint-react-server-status]: https://img.shields.io/npm/v/frint-react-server.svg
+[frint-router-status]: https://img.shields.io/npm/v/frint-router.svg
+[frint-router-react-status]: https://img.shields.io/npm/v/frint-router-react.svg
+[frint-cli-status]: https://img.shields.io/npm/v/frint-cli.svg
+[frint-compat-status]: https://img.shields.io/npm/v/frint-compat.svg
+[frint-component-utils-status]: https://img.shields.io/npm/v/frint-component-utils.svg
+[frint-component-handlers-status]: https://img.shields.io/npm/v/frint-component-handlers.svg
+[frint-test-utils-status]: https://img.shields.io/npm/v/frint-test-utils.svg
 
-Used internally in the monorepo:
-
-* [frint-test-utils](./packages/frint-test-utils): Test utilities.
+[frint-package]: https://npmjs.com/package/frint
+[frint-store-package]: https://npmjs.com/package/frint-store
+[frint-model-package]: https://npmjs.com/package/frint-model
+[frint-data-package]: https://npmjs.com/package/frint-data
+[frint-react-package]: https://npmjs.com/package/frint-react
+[frint-react-server-package]: https://npmjs.com/package/frint-react-server
+[frint-router-package]: https://npmjs.com/package/frint-router
+[frint-router-react-package]: https://npmjs.com/package/frint-router-react
+[frint-cli-package]: https://npmjs.com/package/frint-cli
+[frint-compat-package]: https://npmjs.com/package/frint-compat
+[frint-component-utils-package]: https://npmjs.com/package/frint-component-utils
+[frint-component-handlers-package]: https://npmjs.com/package/frint-component-handlers
+[frint-test-utils-package]: https://npmjs.com/package/frint-test-utils
 
 ## Community projects
 

--- a/packages/frint-model/README.md
+++ b/packages/frint-model/README.md
@@ -4,6 +4,10 @@
 
 > Model package for Frint
 
+# WARNING: This package has been deprecated!
+
+Use [`frint-data`](https://frint.js.org/docs/packages/frint-data/) instead.
+
 <!-- MarkdownTOC autolink=true bracket=round -->
 
 - [Guide](#guide)

--- a/packages/frint-model/src/index.js
+++ b/packages/frint-model/src/index.js
@@ -1,3 +1,4 @@
+// @TODO: remove this package later
 import createModel from './createModel';
 import Model from './Model';
 

--- a/site/partials/docsSidebar.html
+++ b/site/partials/docsSidebar.html
@@ -14,7 +14,6 @@
 
     <ul class="menu-list">
       <li><a href="/docs/packages/frint">frint</a></li>
-      <li><a href="/docs/packages/frint-model">frint-model</a></li>
       <li><a href="/docs/packages/frint-store">frint-store</a></li>
       <li><a href="/docs/packages/frint-data">frint-data</a></li>
       <li><a href="/docs/packages/frint-react">frint-react</a></li>


### PR DESCRIPTION
Closes #306 

The package will ultimately be removed from this repo once the migration has completed to `frint-data` in our applications.