### PR TITLE
frint-store: Deprecate `thunkArgument`, and introduce `deps`

### DIFF
--- a/examples/counter-ts/core/app/index.ts
+++ b/examples/counter-ts/core/app/index.ts
@@ -23,7 +23,7 @@ export default createApp({
             },
           },
           reducer: rootReducer,
-          thunkArgument: { app },
+          deps: { app },
         });
 
         return new Store();

--- a/examples/counter/core/app/index.js
+++ b/examples/counter/core/app/index.js
@@ -22,7 +22,7 @@ export default createApp({
             }
           },
           reducer: rootReducer,
-          thunkArgument: { app },
+          deps: { app },
         });
 
         return new Store();

--- a/examples/kitchensink/app-color/app/index.js
+++ b/examples/kitchensink/app-color/app/index.js
@@ -25,7 +25,7 @@ export default createApp({
           },
           reducer: rootReducer,
           epic: colorEpic$,
-          thunkArgument: { app },
+          deps: { app },
         });
 
         return new Store();

--- a/examples/kitchensink/app-counter/app/index.js
+++ b/examples/kitchensink/app-counter/app/index.js
@@ -22,7 +22,7 @@ export default createApp({
             }
           },
           reducer: rootReducer,
-          thunkArgument: { app },
+          deps: { app },
         });
 
         return new Store();

--- a/examples/kitchensink/app-todos/app/index.js
+++ b/examples/kitchensink/app-todos/app/index.js
@@ -32,7 +32,7 @@ export default createApp({
             },
           },
           reducer: rootReducer,
-          thunkArgument: { app },
+          deps: { app },
         });
 
         return new Store();

--- a/packages/frint-store/README.md
+++ b/packages/frint-store/README.md
@@ -267,13 +267,13 @@ Epics allow you to take full advantage of RxJS, and it makes it easier to handle
 
 ## Extra arguments
 
-You can use the `thunkArgument` option when defining your Store:
+You can use the `deps` option when defining your Store:
 
 ```js
 const Store = createStore({
   reducer: rootReducer,
   epic: rootEpic,
-  thunkArgument: { foo: 'some value' }
+  deps: { foo: 'some value' }
 });
 ```
 
@@ -316,7 +316,8 @@ This package is a close implementation of the APIs introduced by the awesome `re
     * `options.initialState` (`Any`): Default state to start with, defaults to `null`.
     * `options.console`: Override global console with something custom for logging.
     * `options.appendAction` (`Object`): Append extra values to Action payload.
-    * `options.thunkArgument` (`Any`): Extra argument to pass to async actions.
+    * `options.thunkArgument` (`Any`): Deprecated, use `deps` instead.
+    * `options.deps` (`Any`): Extra argument to pass to async actions.
     * `options.enableLogger` (`Boolean`): Enable/disable logging in development mode.
 
 ### Returns
@@ -393,7 +394,7 @@ Dispatches the action, which will later trigger changes in state.
 The `action` argument can also be a function:
 
 ```js
-function (dispatch, getState, thunkArgument) {
+function (dispatch, getState, deps) {
   dispatch(actionPayload);
 }
 ```

--- a/packages/frint-store/src/Store.js
+++ b/packages/frint-store/src/Store.js
@@ -6,7 +6,7 @@ import ActionsObservable from './ActionsObservable';
 function Store(options = {}) {
   this.options = {
     initialState: undefined,
-    thunkArgument: null,
+    deps: null,
     appendAction: false,
     reducer: state => state,
     epic: null,
@@ -14,6 +14,11 @@ function Store(options = {}) {
     console: console,
     ...options,
   };
+
+  if (this.options.thunkArgument) {
+    console.warn('[DEPRECATED] Use `deps` instead of `thunkArgument` option');
+    this.options.deps = this.options.thunkArgument;
+  }
 
   this.internalState$ = new BehaviorSubject(this.options.initialState)
     .scan((previousState, action) => {
@@ -85,7 +90,7 @@ function Store(options = {}) {
     this._epic$ = new Subject();
 
     this._epicSubscription = this._epic$
-      .map(epic => epic(this._action$, this, this.options.thunkArgument))
+      .map(epic => epic(this._action$, this, this.options.deps))
       .switchMap(output$ => output$)
       .subscribe(this.dispatch);
 
@@ -108,7 +113,7 @@ Store.prototype.dispatch = function dispatch(action) {
     return action(
       this.dispatch,
       this.getState,
-      this.options.thunkArgument
+      this.options.deps
     );
   }
 

--- a/packages/frint-store/src/createStore.spec.js
+++ b/packages/frint-store/src/createStore.spec.js
@@ -120,7 +120,7 @@ describe('frint-store › createStore', function () {
     const actions = [];
     const Store = createStore({
       enableLogger: false,
-      thunkArgument: { foo: 'bar' },
+      deps: { foo: 'bar' },
       initialState: {
         counter: 0,
       },

--- a/packages/frint-store/src/createStore.spec.js
+++ b/packages/frint-store/src/createStore.spec.js
@@ -116,7 +116,7 @@ describe('frint-store › createStore', function () {
     subscription.unsubscribe();
   });
 
-  it('dispatches async actions, with thunk argument', function () {
+  it('dispatches async actions, with deps argument', function () {
     const actions = [];
     const Store = createStore({
       enableLogger: false,
@@ -150,10 +150,10 @@ describe('frint-store › createStore', function () {
       });
 
     store.dispatch({ type: 'INCREMENT_COUNTER' });
-    store.dispatch(function (dispatch, getState, thunkArg) {
+    store.dispatch(function (dispatch, getState, deps) {
       dispatch({
         type: 'INCREMENT_COUNTER',
-        thunkArg
+        deps
       });
     });
     store.dispatch({ type: 'DECREMENT_COUNTER' });
@@ -161,7 +161,7 @@ describe('frint-store › createStore', function () {
     expect(actions).to.deep.equal([
       { type: '__FRINT_INIT__' },
       { type: 'INCREMENT_COUNTER' },
-      { type: 'INCREMENT_COUNTER', thunkArg: { foo: 'bar' } },
+      { type: 'INCREMENT_COUNTER', deps: { foo: 'bar' } },
       { type: 'DECREMENT_COUNTER' },
     ]);
 

--- a/site/content/guides/state-management.md
+++ b/site/content/guides/state-management.md
@@ -163,7 +163,7 @@ export default createApp({
       useFactory: function ({ app }) { // the `app` instance via `deps`
         const Store = createStore({
           reducer: rootReducer,
-          thunkArgument: { app }
+          deps: { app }
         });
 
         return new Store();
@@ -183,7 +183,7 @@ export function incrementCounterAsync() {
   return function (dispatch, getState, { app }) {
     // `dispatch(actionPayload)` can dispatch another action
     // `getState()` returns the current state object
-    // `app` is available because of `thunkArgument`
+    // `app` is available because of `deps`
 
     setTimeout(function () {
       dispatch(incrementCounter()); // increment after 2 seconds


### PR DESCRIPTION
Closes #282 

## After merge

* [ ] Immediately release a new version, otherwise apps scaffolded via `frint init` would fail