### PR TITLE
Show  deprecated warnings when creating Store and Model classes

### DIFF
--- a/packages/frint-model/src/createModel.js
+++ b/packages/frint-model/src/createModel.js
@@ -4,6 +4,8 @@ import _ from 'lodash';
 import BaseModel from './Model';
 
 export default function createModel(extend = {}) {
+  console.warn('[DEPRECATED] frint-model has been deprecated, use frint-data instead');
+
   class Model extends BaseModel {
     constructor(...args) {
       super(...args);

--- a/packages/frint-store/src/Store.js
+++ b/packages/frint-store/src/Store.js
@@ -15,11 +15,6 @@ function Store(options = {}) {
     ...options,
   };
 
-  if (this.options.thunkArgument) {
-    console.warn('[DEPRECATED] Use `deps` instead of `thunkArgument` option');
-    this.options.deps = this.options.thunkArgument;
-  }
-
   this.internalState$ = new BehaviorSubject(this.options.initialState)
     .scan((previousState, action) => {
       let updatedState;

--- a/packages/frint-store/src/createStore.js
+++ b/packages/frint-store/src/createStore.js
@@ -3,6 +3,11 @@ import _ from 'lodash';
 import BaseStore from './Store';
 
 export default function createStore(options = {}) {
+  if (options.thunkArgument) {
+    console.warn('[DEPRECATED] Use `deps` instead of `thunkArgument` option');
+    options.deps = options.thunkArgument;
+  }
+
   class Store extends BaseStore {
     constructor(opts = {}) {
       super(_.merge(


### PR DESCRIPTION
Doing so would show warnings right when they are created, instead of waiting for them to be instantiated later (which may or may not happen in an App).

This allows us to catch the warnings early on and more reliably.