### PR TITLE
Update .gitignore to ignore all JetBrains IDEs files under .idea folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,26 +88,8 @@ GitHub.sublime-settings
 ### WebStorm ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
-
-# User-specific stuff:
-.idea/workspace.xml
-.idea/tasks.xml
-
-# Sensitive or high-churn files:
-.idea/dataSources/
-.idea/dataSources.ids
-.idea/dataSources.xml
-.idea/dataSources.local.xml
-.idea/sqlDataSources.xml
-.idea/dynamic.xml
-.idea/uiDesigner.xml
-
-# Gradle:
-.idea/gradle.xml
-.idea/libraries
-
-# Mongo Explorer plugin:
-.idea/mongoSettings.xml
+# All files under .idea are workspace/user-specific
+.idea/**
 
 ## File-based project format:
 *.iws


### PR DESCRIPTION
Officially JetBrains suggests to add only certain files to `.gitignore` file: https://github.com/github/gitignore/blob/master/Global/JetBrains.gitignore

There're quite some files it doesn't cover. For example in my case:
```
.idea/codeStyleSettings.xml
.idea/frint.iml
.idea/inspectionProfiles/Project_Default.xml
.idea/misc.xml
.idea/modules.xml
.idea/preferred-vcs.xml
.idea/vcs.xml
```
I think since we're all using different IDEs there's no point of adding any files from .idea folder to the project. 