### PR TITLE
Webpack: fix for dists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,13 @@ lib
 _site
 package-lock.json
 
+examples/**/build/js/*.js
+examples/**/build/js/*.map
+examples/**/build/*.js
+examples/**/build/*.map
+
+repl/js/*.js
+
 # Ignore vim temporary files
 *~
 *.swp
@@ -118,11 +125,3 @@ fabric.properties
 # modules.xml
 # .idea/misc.xml
 # *.ipr
-
-examples/**/build/js/*.js
-examples/**/build/js/*.map
-examples/**/build/*.js
-examples/**/build/*.map
-
-dist/frint.js
-dist/frint.min.js

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,20 @@ site-publish-only:
 	(cd ./_site && git push git@github.com:Travix-International/frint gh-pages --force)
 
 ##
+# REPL
+#
+repl-update-dists:
+	npm run dist
+	cp -rf ./packages/frint*/dist/ ./repl/js/
+
+repl-serve-only:
+	./node_modules/.bin/live-server --port=6002 ./repl
+
+repl-serve:
+	make repl-update-dists
+	make repl-serve-only
+
+##
 # Usage stats
 #
 define list_usage_in_source

--- a/packages/frint-compat/webpack.config.js
+++ b/packages/frint-compat/webpack.config.js
@@ -21,20 +21,10 @@ module.exports = {
   output: {
     path: __dirname + '/dist',
     filename: filename,
-    libraryTarget: 'this',
+    libraryTarget: 'umd',
     library: 'FrintCompat'
   },
-  externals: Object.assign({}, {
-    'frint': 'Frint',
-    'frint-model': 'FrintModel',
-    'frint-react': 'FrintReact',
-    'frint-store': 'FrintStore',
-    'lodash': '_',
-    'prop-types': 'PropTypes',
-    'react': 'React',
-    'react-dom': 'ReactDOM',
-    'rxjs': 'Rx',
-  }, externals),
+  externals: externals,
   target: 'web',
   plugins: plugins,
   module: {

--- a/packages/frint-component-handlers/webpack.config.js
+++ b/packages/frint-component-handlers/webpack.config.js
@@ -21,13 +21,10 @@ module.exports = {
   output: {
     path: __dirname + '/dist',
     filename: filename,
-    libraryTarget: 'this',
+    libraryTarget: 'umd',
     library: 'FrintComponentHandlers'
   },
-  externals: Object.assign({}, {
-    'lodash': '_',
-    'rxjs': 'Rx',
-  }, externals),
+  externals: externals,
   target: 'web',
   plugins: plugins,
   module: {

--- a/packages/frint-component-utils/webpack.config.js
+++ b/packages/frint-component-utils/webpack.config.js
@@ -21,13 +21,10 @@ module.exports = {
   output: {
     path: __dirname + '/dist',
     filename: filename,
-    libraryTarget: 'this',
+    libraryTarget: 'umd',
     library: 'FrintComponentUtils'
   },
-  externals: Object.assign({}, {
-    'lodash': '_',
-    'rxjs': 'Rx',
-  }, externals),
+  externals: externals,
   target: 'web',
   plugins: plugins,
   module: {

--- a/packages/frint-config/README.md
+++ b/packages/frint-config/README.md
@@ -38,4 +38,4 @@ const config = require('frint-config');
 
 > externals
 
-Webpack's `externals` equivalent object for use in your own bundler.
+Webpack's `externals` equivalent array for use in your own bundler.

--- a/packages/frint-config/package.json
+++ b/packages/frint-config/package.json
@@ -27,6 +27,9 @@
   "keywords": [
     "frint"
   ],
+  "dependencies": {
+    "webpack-rxjs-externals": "^1.0.0"
+  },
   "devDependencies": {
     "cross-env": "^5.0.5"
   },

--- a/packages/frint-config/src/externals.js
+++ b/packages/frint-config/src/externals.js
@@ -1,3 +1,4 @@
+/* eslint-disable func-names */
 /**
  * Webpack's `externals` equivalent object,
  * listing dependencies that Frint packages use.

--- a/packages/frint-config/src/externals.js
+++ b/packages/frint-config/src/externals.js
@@ -2,40 +2,65 @@
  * Webpack's `externals` equivalent object,
  * listing dependencies that Frint packages use.
  */
-export default {
-  // lodash
-  'lodash/cloneDeep': { root: ['_', 'cloneDeep'] },
-  'lodash/each': { root: ['_', 'each'] },
-  'lodash/find': { root: ['_', 'find'] },
-  'lodash/findIndex': { root: ['_', 'findIndex'] },
-  'lodash/first': { root: ['_', 'first'] },
-  'lodash/includes': { root: ['_', 'includes'] },
-  'lodash/isArray': { root: ['_', 'isArray'] },
-  'lodash/isEqual': { root: ['_', 'isEqual'] },
-  'lodash/isPlainObject': { root: ['_', 'isPlainObject'] },
-  'lodash/last': { root: ['_', 'last'] },
-  'lodash/get': { root: ['_', 'get'] },
-  'lodash/set': { root: ['_', 'set'] },
-  'lodash/mapValues': { root: ['_', 'mapValues'] },
-  'lodash/merge': { root: ['_', 'merge'] },
-  'lodash/omit': { root: ['_', 'omit'] },
-  'lodash/padStart': { root: ['_', 'padStart'] },
-  'lodash/tail': { root: ['_', 'tail'] },
-  'lodash/take': { root: ['_', 'take'] },
-  'lodash/takeRight': { root: ['_', 'takeRight'] },
-  'lodash/zipObject': { root: ['_', 'zipObject'] },
-  'lodash/zipWith': { root: ['_', 'zipWith'] },
+import webpackRxjsExternals from 'webpack-rxjs-externals';
 
-  // rxjs
-  'rxjs/BehaviorSubject': { root: ['Rx', 'BehaviorSubject'] },
-  'rxjs/Observable': { root: ['Rx', 'Observable'] },
-  'rxjs/Subject': { root: ['Rx', 'Subject'] },
-  'rxjs/operator/concatMap': { root: ['Rx', 'Observable', 'prototype', 'concatMap'] },
-  'rxjs/operator/find': { root: ['Rx', 'Observable', 'prototype', 'find'] },
-  'rxjs/operator/first': { root: ['Rx', 'Observable', 'prototype', 'first'] },
-  'rxjs/operator/map': { root: ['Rx', 'Observable', 'prototype', 'map'] },
-  'rxjs/observable/merge': { root: ['Rx', 'Observable', 'merge'] },
-  'rxjs/observable/of': { root: ['Rx', 'Observable', 'of'] },
-  'rxjs/operator/scan': { root: ['Rx', 'Observable', 'prototype', 'scan'] },
-  'rxjs/operator/switchMap': { root: ['Rx', 'Observable', 'prototype', 'switchMap'] },
-};
+export default [
+  // rxjs/*
+  webpackRxjsExternals(),
+
+  // lodash/*
+  function (context, request, callback) {
+    if (request.startsWith('lodash/')) {
+      const subModule = request.split('/')[1];
+
+      return callback(null, {
+        root: ['_', subModule],
+        commonjs: request,
+        commonjs2: request,
+        amd: request,
+      });
+    }
+
+    return callback();
+  },
+
+  // full imports
+  {
+    'lodash': {
+      root: '_',
+      commonjs: 'lodash',
+      commonjs2: 'lodash',
+      amd: 'lodash',
+    },
+    'rxjs': {
+      root: 'Rx',
+      commonjs: 'rxjs',
+      commonjs2: 'rxjs',
+      amd: 'rxjs',
+    },
+    'react': {
+      root: 'React',
+      commonjs: 'react',
+      commonjs2: 'react',
+      amd: 'react',
+    },
+    'react': {
+      root: 'React',
+      commonjs: 'react',
+      commonjs2: 'react',
+      amd: 'react',
+    },
+    'react-dom': {
+      root: 'ReactDOM',
+      commonjs: 'react-dom',
+      commonjs2: 'react-dom',
+      amd: 'react-dom',
+    },
+    'prop-types': {
+      root: 'PropTypes',
+      commonjs: 'prop-types',
+      commonjs2: 'prop-types',
+      amd: 'prop-types',
+    },
+  },
+];

--- a/packages/frint-config/src/externals.js
+++ b/packages/frint-config/src/externals.js
@@ -44,12 +44,6 @@ export default [
       commonjs2: 'react',
       amd: 'react',
     },
-    'react': {
-      root: 'React',
-      commonjs: 'react',
-      commonjs2: 'react',
-      amd: 'react',
-    },
     'react-dom': {
       root: 'ReactDOM',
       commonjs: 'react-dom',

--- a/packages/frint-data/webpack.config.js
+++ b/packages/frint-data/webpack.config.js
@@ -21,13 +21,10 @@ module.exports = {
   output: {
     path: __dirname + '/dist',
     filename: filename,
-    libraryTarget: 'this',
+    libraryTarget: 'umd',
     library: 'FrintData'
   },
-  externals: Object.assign({}, {
-    'lodash': '_',
-    'rxjs': 'Rx',
-  }, externals),
+  externals: externals,
   target: 'web',
   plugins: plugins,
   module: {

--- a/packages/frint-model/webpack.config.js
+++ b/packages/frint-model/webpack.config.js
@@ -21,13 +21,10 @@ module.exports = {
   output: {
     path: __dirname + '/dist',
     filename: filename,
-    libraryTarget: 'this',
+    libraryTarget: 'umd',
     library: 'FrintModel'
   },
-  externals: Object.assign({}, {
-    'lodash': '_',
-    'rxjs': 'Rx',
-  }, externals),
+  externals: externals,
   target: 'web',
   plugins: plugins,
   module: {

--- a/packages/frint-react/webpack.config.js
+++ b/packages/frint-react/webpack.config.js
@@ -21,17 +21,17 @@ module.exports = {
   output: {
     path: __dirname + '/dist',
     filename: filename,
-    libraryTarget: 'this',
+    libraryTarget: 'umd',
     library: 'FrintReact'
   },
-  externals: Object.assign({}, {
-    'frint': 'Frint',
-    'lodash': '_',
-    'prop-types': 'PropTypes',
-    'react': 'React',
-    'react-dom': 'ReactDOM',
-    'rxjs': 'Rx',
-  }, externals),
+  externals: externals.concat([{
+    'frint': {
+      root: 'Frint',
+      commonjs: 'frint',
+      commonjs2: 'frint',
+      amd: 'frint',
+    },
+  }]),
   target: 'web',
   plugins: plugins,
   module: {

--- a/packages/frint-router-component-handlers/package.json
+++ b/packages/frint-router-component-handlers/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "cross-env": "^5.0.5",
     "frint": "^3.1.0",
+    "frint-config": "^3.1.0",
     "frint-router": "^3.1.0"
   },
   "bugs": {

--- a/packages/frint-router-component-handlers/webpack.config.js
+++ b/packages/frint-router-component-handlers/webpack.config.js
@@ -1,4 +1,5 @@
 var webpack = require('webpack');
+var externals = require('frint-config').externals;
 
 var minify = process.env.DIST_MIN;
 var plugins = !minify
@@ -20,13 +21,10 @@ module.exports = {
   output: {
     path: __dirname + '/dist',
     filename: filename,
-    libraryTarget: 'this',
+    libraryTarget: 'umd',
     library: 'FrintRouterComponentHandlers'
   },
-  externals: {
-    'lodash': '_',
-    'rxjs': 'Rx',
-  },
+  externals: externals,
   target: 'web',
   plugins: plugins,
   module: {

--- a/packages/frint-router-react/webpack.config.js
+++ b/packages/frint-router-react/webpack.config.js
@@ -21,17 +21,25 @@ module.exports = {
   output: {
     path: __dirname + '/dist',
     filename: filename,
-    libraryTarget: 'this',
+    libraryTarget: 'umd',
     library: 'FrintRouterReact'
   },
-  externals: Object.assign({}, {
-    'lodash': '_',
-    'react': 'React',
-    'rxjs': 'Rx',
-    'prop-types': 'PropTypes',
-    'frint-react': 'FrintReact',
-    'frint-router': 'FrintRouter',
-  }, externals),
+  externals: externals.concat([
+    {
+      'frint-react': {
+        root: 'FrintReact',
+        commonjs: 'frint-react',
+        commonjs2: 'frint-react',
+        amd: 'frint-react',
+      },
+      'frint-router': {
+        root: 'FrintRouter',
+        commonjs: 'frint-router',
+        commonjs2: 'frint-router',
+        amd: 'frint-router',
+      },
+    },
+  ]),
   target: 'web',
   plugins: plugins,
   module: {

--- a/packages/frint-router/webpack.config.js
+++ b/packages/frint-router/webpack.config.js
@@ -21,15 +21,10 @@ module.exports = {
   output: {
     path: __dirname + '/dist',
     filename: filename,
-    libraryTarget: 'this',
+    libraryTarget: 'umd',
     library: 'FrintRouter'
   },
-  externals: Object.assign({}, {
-    'lodash': '_',
-    'react': 'React',
-    'rxjs': 'Rx',
-    'prop-types': 'PropTypes',
-  }, externals),
+  externals: externals,
   target: 'web',
   plugins: plugins,
   module: {

--- a/packages/frint-store/webpack.config.js
+++ b/packages/frint-store/webpack.config.js
@@ -21,13 +21,10 @@ module.exports = {
   output: {
     path: __dirname + '/dist',
     filename: filename,
-    libraryTarget: 'this',
+    libraryTarget: 'umd',
     library: 'FrintStore'
   },
-  externals: Object.assign({}, {
-    'lodash': '_',
-    'rxjs': 'Rx',
-  }, externals),
+  externals: externals,
   target: 'web',
   plugins: plugins,
   module: {

--- a/packages/frint/webpack.config.js
+++ b/packages/frint/webpack.config.js
@@ -21,13 +21,10 @@ module.exports = {
   output: {
     path: __dirname + '/dist',
     filename: filename,
-    libraryTarget: 'this',
+    libraryTarget: 'umd',
     library: 'Frint',
   },
-  externals: Object.assign({}, {
-    'lodash': '_',
-    'rxjs': 'Rx',
-  }, externals),
+  externals: externals,
   target: 'web',
   plugins: plugins,
   module: {

--- a/repl/README.md
+++ b/repl/README.md
@@ -1,0 +1,3 @@
+# REPL
+
+This REPL is aimed at FrintJS maintainers for quickly testing out the dists of packages locally.

--- a/repl/index.html
+++ b/repl/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>FrintJS REPL</title>
+
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.5.3/css/bulma.min.css" />
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+
+  <body>
+    <section class="editor-section">
+      <div class="columns">
+        <div class="column editor-column">
+          <div id="editor"></div>
+        </div>
+
+        <div class="column root-column">
+          <div id="root"></div>
+        </div>
+      </div>
+
+      <div class="footer">
+        <a href="/">Clear</a>
+      </div>
+    </section>
+
+    <!-- third-party libs -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.4/lodash.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/rxjs/5.0.1/Rx.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prop-types/15.5.10/prop-types.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/0.14.8/react.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/0.14.8/react-dom.min.js"></script>
+
+    <!-- frint -->
+    <script src="/js/frint.js"></script>
+    <script src="/js/frint-store.js"></script>
+    <script src="/js/frint-model.js"></script>
+    <script src="/js/frint-react.js"></script>
+
+    <!-- babel -->
+    <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+
+    <!-- editor -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.6/ace.js"></script>
+    <script src="/repl.js"></script>
+  </body>
+</html>

--- a/repl/repl.js
+++ b/repl/repl.js
@@ -1,0 +1,204 @@
+const initialCode = `
+// import
+const { createApp } = Frint;
+const { render, observe, streamProps } = FrintReact;
+const { createStore, combineReducers } = FrintStore;
+
+// constants
+const INCREMENT_COUNTER = 'INCREMENT_COUNTER';
+const DECREMENT_COUNTER = 'DECREMENT_COUNTER';
+
+// actions
+function incrementCounter() {
+  return {
+    type: INCREMENT_COUNTER
+  };
+}
+
+function decrementCounter() {
+  return {
+    type: DECREMENT_COUNTER
+  };
+}
+
+// reducers
+const INITIAL_STATE = {
+  value: 0
+};
+
+function counterReducer(state = INITIAL_STATE, action) {
+  switch (action.type) {
+    case INCREMENT_COUNTER:
+      return Object.assign({}, {
+        value: state.value + 1
+      });
+
+    case DECREMENT_COUNTER:
+      return Object.assign({}, {
+        value: state.value - 1
+      });
+
+    default:
+      return state;
+  }
+}
+
+const rootReducer = combineReducers({
+  counter: counterReducer,
+});
+
+// component
+const Root = observe(function (app) {
+  const store = app.get('store');
+
+  return streamProps({})
+    .set(
+      store.getState$(),
+      state => ({ counter: state.counter.value })
+    )
+    .setDispatch({
+      increment: incrementCounter,
+      decrement: decrementCounter,
+    }, store)
+    .get$();
+})(function (props) {
+  const { counter, increment, decrement } = props;
+
+  return (
+    <div>
+      <p>Counter value: <code>{counter}</code></p>
+
+      <div>
+        <button
+          className="button button-primary"
+          onClick={() => increment()}
+        >
+          +
+        </button>
+
+        <button
+          className="button"
+          onClick={() => decrement()}
+        >
+          -
+        </button>
+      </div>
+    </div>
+  );
+});
+
+// App
+const App = createApp({
+  name: 'MyTestApp',
+  providers: [
+    {
+      name: 'component',
+      useValue: Root
+    },
+    {
+      name: 'store',
+      useFactory: ({ app }) => {
+        const Store = createStore({
+          initialState: {
+            counter: {
+              value: 5,
+            }
+          },
+          reducer: rootReducer,
+          deps: { app },
+        });
+
+        return new Store();
+      },
+      deps: ['app'],
+    },
+  ]
+});
+
+// render
+const app = new App();
+render(app, document.getElementById('root'));
+`.trim();
+
+// editor
+const editor = ace.edit('editor');
+editor.setTheme('ace/theme/chrome');
+editor.getSession().setMode('ace/mode/javascript');
+editor.getSession().setTabSize(4);
+editor.getSession().setUseSoftTabs(true);
+editor.setShowPrintMargin(false);
+
+function renderToRoot() {
+  ReactDOM.unmountComponentAtNode(document.getElementById('root'));
+
+  const input = editor.getValue();
+
+  try {
+    const output = Babel.transform(input, {
+      presets: [
+        'es2015',
+        'react',
+      ]
+    }).code;
+
+    eval(output);
+    updateUrlHash(input);
+  } catch (error) {
+    throw error;
+  }
+}
+
+function parseHashParams(hash) {
+  const params = hash
+    .split('#?')[1];
+
+  if (!params) {
+    return {};
+  }
+
+  return params
+    .split('&')
+    .map(function (item) {
+      const kv = item.split('=');
+      const key = kv[0];
+      const value = kv[1];
+      return { [key]: value };
+    })
+    .reduce(function (acc, val) {
+      return Object.assign({}, acc, val);
+    }, {});
+}
+
+function updateUrlHash(code = null) {
+  const currentHashParams= parseHashParams(location.hash);
+  currentHashParams.code = escape(code);
+
+  const stringifiedParams = Object.keys(currentHashParams)
+    .map(function (key) {
+      return key + '=' + currentHashParams[key];
+    })
+    .join('&');
+
+  if (history.pushState) {
+    history.pushState(null, null, '#?' + stringifiedParams);
+  }
+}
+
+
+(function () {
+  // get code from URL on first page-load
+  const parsedParams = parseHashParams(location.hash);
+  if (typeof parsedParams.code !== 'undefined') {
+    editor.setValue(unescape(parsedParams.code));
+  } else {
+    editor.setValue(initialCode);
+  }
+
+  // re-render on changes
+  editor.getSession().on('change', _.debounce(function (e) {
+    renderToRoot();
+  }, 300));
+
+  // initial render
+  renderToRoot();
+})();

--- a/repl/styles.css
+++ b/repl/styles.css
@@ -1,0 +1,40 @@
+html,
+body {
+  height: 100%;
+}
+
+.editor-section {
+  top: 10px;
+  margin-bottom: 10px;
+}
+
+.editor-section,
+.editor-section .columns,
+.editor-column {
+  position: relative;
+  height: 100%;
+}
+
+.editor-column {
+  border-right: 1px solid #eee;
+}
+
+.root-column {
+  background: #fff;
+}
+
+#editor {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}
+
+.footer {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  z-index: 1000;
+  padding: 0;
+}


### PR DESCRIPTION
Closes #331 

## What's done

In webpack configs, `libraryTarget` has been changed to `umd`. 

Only then `externals` for libraries with deep paths (like `rxjs/Observable` instead of just `rxjs`) take effect.

## Local REPL

Introduced a local REPL to quickly test locally built dists:

```
$ make repl-serve
```

## Dist sizes

```
$ make list-dists
original 	 gzipped 	 file
--- 		 --- 		 ---
23.4K 		 4.2K 		 ./packages/frint-data/dist/frint-data.min.js
17.0K 		 3.8K 		 ./packages/frint-react/dist/frint-react.min.js
16.0K 		 3.4K 		 ./packages/frint-router-react/dist/frint-router-react.min.js
26.3K 		 7.9K 		 ./packages/frint-router/dist/frint-router.min.js
9.8K 		 2.9K 		 ./packages/frint-store/dist/frint-store.min.js
12.1K 		 3.1K 		 ./packages/frint/dist/frint.min.js
```