### PR TITLE
frint-react: `observe` HoC can return props synchronously

### DIFF
--- a/packages/frint-react/README.md
+++ b/packages/frint-react/README.md
@@ -473,7 +473,7 @@ Renders a Root App in target DOM node.
     * The `fn` accepts two arguments:
       * `app`: the instance of your Root App or the App in scope
       * `props$`: an Observable of props being passed by parent component (if any)
-    * It should return an `Observable`
+    * It should return an `Observable` or `Object`
 
 ### Returns
 

--- a/packages/frint-react/src/components/observe.spec.js
+++ b/packages/frint-react/src/components/observe.spec.js
@@ -186,4 +186,40 @@ describe('frint-react › components › observe', function () {
     expect(wrapper.find('#name')).to.have.length(1);
     expect(wrapper.text()).to.contain('I am a child');
   });
+
+  it('can return props synchronously', function () {
+    function Component({ name }) {
+      return (
+        <div>
+          <p id="name">{name}</p>
+        </div>
+      );
+    }
+
+    const ObservedComponent = observe(function (app) {
+      return {
+        name: app.getName(),
+      };
+    })(Component);
+
+    const fakeApp = {
+      getName() {
+        return 'FakeApp';
+      }
+    };
+
+    function ComponentToRender(props) {
+      return (
+        <Provider app={fakeApp}>
+          <ObservedComponent {...props} />
+        </Provider>
+      );
+    }
+
+    const wrapper = mount(<ComponentToRender />);
+    expect(wrapper.find(ObservedComponent)).to.have.length(1);
+    expect(wrapper.find(Component)).to.have.length(1);
+    expect(wrapper.find('#name')).to.have.length(1);
+    expect(wrapper.text()).to.contain('FakeApp');
+  });
 });


### PR DESCRIPTION
Closes #338 

## What's done

`observe` higher-order component can now return props synchronously too, which helps in server-side rendering.

## Usage

If the beginning of your Component file looks like this:

```js
// components/MyComponent.js
import React from 'react';
import { observe } from 'frint-react';

const MyComponent(props) {
  return <p>App name: {props.name}</p>;
}
```

You can do the final `export` in either of the ways:

### Streaming props

```js
import { Observable } from 'rxjs';

export default observe(function (app) {
  return Observable.of({
    name: app.getName(),
  });
})(MyComponent);
```

### Synchronous props

```js
export default observe(function (app) {
  return {
    name: app.getName(),
  };
})(MyComponent);
```

## Server-side usage

Like mentioned in #338, combining environment variables usage in the server along with Webpack's DefinePlugin in the bundler, the final export can look like this:

```js
import { Observable } from 'rxjs';

export default observe(function (app) {
  // sync (for the server)
  if (process.env.BABEL_ENV === 'server') {
    return {
      name: app.getName(),
    };
  }

  // streaming props (for the bundle)
  return Observable.of({
    name: app.getName(),
  });
})(MyComponent);
```