### PR TITLE
frint-react: load only required modules for `render`

### DIFF
--- a/packages/frint-react/src/render.js
+++ b/packages/frint-react/src/render.js
@@ -1,11 +1,11 @@
-/* eslint-disable import/no-extraneous-dependencies */
+/* eslint-disable import/no-extraneous-dependencies, global-require */
 import React from 'react';
-import ReactDOM from 'react-dom';
 
-import FrintReact from './';
+import getMountableComponent from './components/getMountableComponent';
 
 export default function render(app, node) {
-  const MountableComponent = FrintReact.getMountableComponent(app);
+  const MountableComponent = getMountableComponent(app);
+  const ReactDOM = require('react-dom');
 
   return ReactDOM.render(<MountableComponent />, node);
 }


### PR DESCRIPTION
## What's done

### 1: Import only required modules

We were loading the entire `frint-react` library inside the `render` function, when we only needed one specific module there.

We were doing it like this so far for `frint-compat` for supporting v0.x users, which is not needed any more.

### 2: `react-dom` imported inside `render`

`react-dom` is now imported **inside** the `render` function. This has no side-effect, and is mainly done for making way for supporting React Native soon.

React Native doesn't require `react-dom`, and `react-dom` is treated as a peer dependency of `frint-react`.

This means when `frint-react` will be used in a React Native project, where the developer doesn't need to install `react-dom`, it will not throw any error when any module is imported from the package like this:

```js
import { observe } from 'frint-react';
```

Directly importing the module from package like this will also bring in`render` as a function, but since that function will never be executed, it means `react-dom` will also never be required, resulting in no error.