### PR TITLE
Add `frint-react-native`

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The framework is a collection of these packages, which can be composed together 
 ## Community projects
 
 * [frint-vue](https://github.com/frintjs/frint-vue): Vue.js integration
+* [frint-react-native](https://github.com/frintjs/frint-react-native): React Native integration
 
 ## License
 


### PR DESCRIPTION
Closes #333 

Listed under community projects in root README.

Read more here: https://github.com/frintjs/frint-react-native

## Preview

Screenshot of an iOS app built with FrintJS + React Native:

<img width="559" alt="screen shot 2017-10-17 at 19 46 01" src="https://user-images.githubusercontent.com/20046/31685547-9f9b271e-b383-11e7-9fd4-2962c18e8981.png">
