### PR TITLE
Fixed frint-router-react tests for React 16 compatibility

### DIFF
--- a/packages/frint-react/src/components/Region.spec.js
+++ b/packages/frint-react/src/components/Region.spec.js
@@ -39,8 +39,7 @@ describe('frint-react › components › Region', function () {
     );
 
     const element = document.getElementById('my-component');
-    expect(element.innerHTML.startsWith('<!-- react-empty: ')).to.equal(true);
-    expect(element.innerHTML.endsWith(' -->')).to.equal(true);
+    expect(element.innerHTML).to.eql('');
   });
 
   it('renders apps with weighted ordering', function () {

--- a/packages/frint-router-react/src/Link.spec.js
+++ b/packages/frint-router-react/src/Link.spec.js
@@ -38,7 +38,7 @@ describe('frint-route-react › Link', () => {
     expect(wrapper.hasClass('anchor')).to.be.true;
 
     expect(wrapper.children().length).to.equal(1);
-    expect(wrapper.children().get(0)).to.equal(linkContent);
+    expect(wrapper.children().get(0)).to.eql(linkContent);
   });
 
   it('renders button with type, className and children when type prop is passed', function () {
@@ -54,7 +54,7 @@ describe('frint-route-react › Link', () => {
     expect(wrapper.hasClass('fancy-button')).to.be.true;
 
     expect(wrapper.children().length).to.equal(1);
-    expect(wrapper.children().get(0)).to.equal(linkContent);
+    expect(wrapper.children().get(0)).to.eql(linkContent);
   });
 
   it('subscribes to router service for  matching route inexactly and changes activeClass accordingly ' +
@@ -73,20 +73,24 @@ describe('frint-route-react › Link', () => {
     );
 
     router.push('/');
-    expect(wrapper.hasClass('anchor')).to.be.true;
-    expect(wrapper.hasClass('anchor-active')).to.be.false;
+    wrapper.update();
+    expect(wrapper.find(Link).children().hasClass('anchor')).to.be.true;
+    expect(wrapper.find(Link).children().hasClass('anchor-active')).to.be.false;
 
     router.push('/about');
-    expect(wrapper.hasClass('anchor')).to.be.true;
-    expect(wrapper.hasClass('anchor-active')).to.be.true;
+    wrapper.update();
+    expect(wrapper.find(Link).children().hasClass('anchor')).to.be.true;
+    expect(wrapper.find(Link).children().hasClass('anchor-active')).to.be.true;
 
     router.push('/about/whatever');
-    expect(wrapper.hasClass('anchor')).to.be.true;
-    expect(wrapper.hasClass('anchor-active')).to.be.true;
+    wrapper.update();
+    expect(wrapper.find(Link).children().hasClass('anchor')).to.be.true;
+    expect(wrapper.find(Link).children().hasClass('anchor-active')).to.be.true;
 
     router.push('/');
-    expect(wrapper.hasClass('anchor')).to.be.true;
-    expect(wrapper.hasClass('anchor-active')).to.be.false;
+    wrapper.update();
+    expect(wrapper.find(Link).children().hasClass('anchor')).to.be.true;
+    expect(wrapper.find(Link).children().hasClass('anchor-active')).to.be.false;
   });
 
   it('subscribes to router service for exactly matching route and changes activeClass accordingly ' +
@@ -106,16 +110,19 @@ describe('frint-route-react › Link', () => {
     );
 
     router.push('/');
-    expect(wrapper.hasClass('anchor-active')).to.be.false;
+    wrapper.update();
+    expect(wrapper.find(Link).children().hasClass('anchor-active')).to.be.false;
 
     router.push('/about');
-    expect(wrapper.hasClass('anchor-active')).to.be.true;
+    wrapper.update();
+    expect(wrapper.find(Link).children().hasClass('anchor-active')).to.be.true;
 
     router.push('/about/whatever');
-    expect(wrapper.hasClass('anchor-active')).to.be.false;
+    wrapper.update();
+    expect(wrapper.find(Link).children().hasClass('anchor-active')).to.be.false;
 
     router.push('/');
-    expect(wrapper.hasClass('anchor-active')).to.be.false;
+    expect(wrapper.find(Link).children().hasClass('anchor-active')).to.be.false;
   });
 
   it('subscribes to router service for matching route and changes activeClass accordingly ' +
@@ -133,14 +140,14 @@ describe('frint-route-react › Link', () => {
     );
 
     router.push('/about');
-    expect(wrapper.hasClass('anchor-active')).to.be.false;
-
+    wrapper.update();
+    expect(wrapper.find(Link).children().hasClass('anchor-active')).to.be.false;
 
     wrapper.setProps({ activeClassName: 'anchor-active' });
-    expect(wrapper.hasClass('anchor-active')).to.be.true;
+    expect(wrapper.find(Link).children().hasClass('anchor-active')).to.be.true;
 
     wrapper.setProps({ activeClassName: 'anchor-super-active' });
-    expect(wrapper.hasClass('anchor-super-active')).to.be.true;
+    expect(wrapper.find(Link).children().hasClass('anchor-super-active')).to.be.true;
   });
 
   it('subscribes to router service for matching route and changes activeClass accordingly ' +
@@ -159,13 +166,15 @@ describe('frint-route-react › Link', () => {
     );
 
     router.push('/about');
-    expect(wrapper.hasClass('anchor-active')).to.be.true;
+    wrapper.update();
+    expect(wrapper.find(Link).children().hasClass('anchor-active')).to.be.true;
 
     wrapper.setProps({ to: '/contact' });
-    expect(wrapper.hasClass('anchor-active')).to.be.false;
+    expect(wrapper.find(Link).children().hasClass('anchor-active')).to.be.false;
 
     router.push('/contact');
-    expect(wrapper.hasClass('anchor-active')).to.be.true;
+    wrapper.update();
+    expect(wrapper.find(Link).children().hasClass('anchor-active')).to.be.true;
   });
 
   it('subscribes to router service for matching route and changes activeClass accordingly ' +
@@ -184,13 +193,17 @@ describe('frint-route-react › Link', () => {
     );
 
     router.push('/about/whatever');
-    expect(wrapper.hasClass('anchor-active')).to.be.true;
+    wrapper.update();
+    expect(wrapper.find(Link).children().hasClass('anchor-active')).to.be.true;
+
 
     wrapper.setProps({ exact: true });
-    expect(wrapper.hasClass('anchor-active')).to.be.false;
+    wrapper.update();
+    expect(wrapper.find(Link).children().hasClass('anchor-active')).to.be.false;
 
     router.push('/about');
-    expect(wrapper.hasClass('anchor-active')).to.be.true;
+    wrapper.update();
+    expect(wrapper.find(Link).children().hasClass('anchor-active')).to.be.true;
   });
 
   it('unsubscribes from router getMatch$ when unmounted and when resubscribes', function () {

--- a/packages/frint-router-react/src/Route.spec.js
+++ b/packages/frint-router-react/src/Route.spec.js
@@ -72,15 +72,19 @@ describe('frint-route-react › Route', function () {
     );
 
     context.app.get('router').push('/');
+    wrapper.update();
     expect(wrapper.type()).to.be.null;
 
     context.app.get('router').push('/about');
+    wrapper.update();
     expect(wrapper.type()).to.equal(Component);
 
     context.app.get('router').push('/service');
+    wrapper.update();
     expect(wrapper.type()).to.be.null;
 
     context.app.get('router').push('/about/contact');
+    wrapper.update();
     expect(wrapper.type()).to.equal(Component);
   });
 
@@ -101,15 +105,19 @@ describe('frint-route-react › Route', function () {
     );
 
     context.app.get('router').push('/');
+    wrapper.update();
     expect(wrapper.type()).to.be.null;
 
     context.app.get('router').push('/about');
+    wrapper.update();
     expect(wrapper.find('.url').text()).to.equal('/about');
 
     context.app.get('router').push('/service');
+    wrapper.update();
     expect(wrapper.type()).to.be.null;
 
     context.app.get('router').push('/about/contact');
+    wrapper.update();
     expect(wrapper.find('.url').text()).to.equal('/about');
   });
 
@@ -123,15 +131,19 @@ describe('frint-route-react › Route', function () {
     );
 
     context.app.get('router').push('/');
+    wrapper.update();
     expect(wrapper.type()).to.be.null;
 
     context.app.get('router').push('/about');
+    wrapper.update();
     expect(wrapper.type()).to.equal(Component);
 
     context.app.get('router').push('/service');
+    wrapper.update();
     expect(wrapper.type()).to.be.null;
 
     context.app.get('router').push('/about/contact');
+    wrapper.update();
     expect(wrapper.type()).to.be.null;
   });
 
@@ -148,10 +160,12 @@ describe('frint-route-react › Route', function () {
     expect(wrapper.type()).to.be.null;
 
     context.app.get('router').push('/about');
+    wrapper.update();
     expect(wrapper.type()).to.equal(Component);
     expect(wrapper.prop('match')).to.include({ url: '/about', isExact: true });
 
     context.app.get('router').push('/about/contact');
+    wrapper.update();
     expect(wrapper.type()).to.equal(Component);
     expect(wrapper.prop('match')).to.include({ url: '/about', isExact: false });
   });
@@ -225,6 +239,7 @@ describe('frint-route-react › Route', function () {
 
     it('gets rendered when path matches', function () {
       context.app.get('router').push('/about');
+      wrapper.update();
       expect(wrapper.html()).to.equal('<article>About</article>');
       expect(wrapper.prop('match')).to.include({ url: '/about' });
     });
@@ -281,6 +296,7 @@ describe('frint-route-react › Route', function () {
 
     it('renders HomeComponent when path matches', function () {
       context.app.get('router').push('/about');
+      wrapper.update();
       expect(wrapper.html()).to.equal('<header>Home</header>');
     });
 

--- a/packages/frint-router-react/src/Switch.spec.js
+++ b/packages/frint-router-react/src/Switch.spec.js
@@ -97,10 +97,9 @@ describe('frint-router-react › Switch', function () {
     );
 
     router.push('/about');
-
-    expect(wrapper.type()).to.equal(Route);
-
-    expect(wrapper.props()).to.deep.equal({
+    wrapper.update();
+    expect(wrapper.type()).to.eql(Route);
+    expect(wrapper.props()).to.eql({
       computedMatch: { url: '/about', isExact: true, params: {} },
       component: FirstComponent,
       path: '/about'
@@ -123,7 +122,7 @@ describe('frint-router-react › Switch', function () {
     );
 
     router.push('/services');
-
+    wrapper.update();
     expect(wrapper.type()).to.equal(Route);
     expect(wrapper.props()).to.deep.equal({
       component: DefaultComponent,


### PR DESCRIPTION
I've fixed tests by following the [migration guide for enzyme v2 to v3](https://github.com/airbnb/enzyme/blob/master/docs/guides/migration-from-2-to-3.md).

