### PR TITLE
frint-config: casing for exported keys

### DIFF
--- a/packages/frint-config/src/externals.js
+++ b/packages/frint-config/src/externals.js
@@ -5,22 +5,24 @@
  */
 import webpackRxJsExternals from 'webpack-rxjs-externals';
 
-export const rxJs = webpackRxJsExternals();
+export const rxjs = [webpackRxJsExternals()];
 
-export const lodash = function (context, request, callback) {
-  if (request.startsWith('lodash/')) {
-    const subModule = request.split('/')[1];
+export const lodash = [
+  function (context, request, callback) {
+    if (request.startsWith('lodash/')) {
+      const subModule = request.split('/')[1];
 
-    return callback(null, {
-      root: ['_', subModule],
-      commonjs: request,
-      commonjs2: request,
-      amd: request,
-    });
+      return callback(null, {
+        root: ['_', subModule],
+        commonjs: request,
+        commonjs2: request,
+        amd: request,
+      });
+    }
+
+    return callback();
   }
-
-  return callback();
-};
+];
 
 // full imports
 export const thirdParties = [{
@@ -111,12 +113,6 @@ export const frint = [{
   }
 }];
 
-export default [
-  // rxjs/*
-  rxJs,
-
-  // lodash/*
-  lodash,
-
-  ...thirdParties
-];
+export default rxjs
+  .concat(lodash)
+  .concat(thirdParties);

--- a/packages/frint-config/src/index.js
+++ b/packages/frint-config/src/index.js
@@ -2,13 +2,13 @@ import externals, {
   frint,
   lodash,
   thirdParties,
-  rxJs
+  rxjs
 } from './externals';
 
 export default {
   externals,
   frintExternals: frint,
   lodashExternals: lodash,
-  thirdPartiesExternals: thirdParties,
-  rxJsExternals: rxJs
+  thirdPartyExternals: thirdParties,
+  rxjsExternals: rxjs,
 };


### PR DESCRIPTION
## What's done

* Casing of exported keys updated
* All exported `externals` are Arrays (which allows easier concatenation when consumed)

PR labelled as `patch` because `frint-config` is treated as an internal package only, as stated in the root README.

Refs #344 